### PR TITLE
Fix workspace limit unions

### DIFF
--- a/internal/resources/attachment_resource.go
+++ b/internal/resources/attachment_resource.go
@@ -374,11 +374,10 @@ var graphAttachmentMappings = map[string]graphAttachmentMapping{
 		TargetType:   graphMcpServerTargetType,
 	},
 	mcpServerWorkspaceAttachmentKind: {
-		SourceHandle:     graphSelfHandle,
-		TargetHandle:     graphWorkspaceHandle,
-		SourceType:       graphWorkspaceSourceType,
-		TargetType:       graphMcpServerTargetType,
-		SwapSourceTarget: true,
+		SourceHandle: graphWorkspaceHandle,
+		TargetHandle: graphSelfHandle,
+		SourceType:   graphMcpServerSourceType,
+		TargetType:   graphWorkspaceSourceType,
 	},
 	workspaceToolAttachmentKind: {
 		SourceHandle: graphSelfHandle,


### PR DESCRIPTION
## Summary
- Add JSON marshal/unmarshal helpers for workspace memory/cpu limit union types in the team client.
- Fix the mcpServer/workspace graph attachment mapping by swapping source/target IDs while using `$self -> workspace` handles.

## Testing
- nix shell --impure nixpkgs#go -c env CGO_ENABLED=0 go vet ./...
- nix shell --impure nixpkgs#go -c env CGO_ENABLED=0 go test ./...

Closes #12