### PR TITLE
docs: clarify resource constraints

### DIFF
--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -29,7 +29,7 @@ resource "agyn_agent" "example" {
 
 ### Optional
 
-- `config` (String, Deprecated) Deprecated JSON-encoded agent configuration. Use structured attributes instead.
+- `config` (String, Deprecated) Deprecated JSON-encoded agent configuration. Use structured attributes instead. Cannot be used together with the structured configuration attributes. Use one approach or the other.
 - `debounce_ms` (Number) Debounce duration in milliseconds.
 - `description` (String) Human-readable description of the agent.
 - `model` (String) Model identifier override for the agent.

--- a/docs/resources/mcp_server.md
+++ b/docs/resources/mcp_server.md
@@ -38,7 +38,7 @@ resource "agyn_mcp_server" "example" {
 ### Optional
 
 - `command` (String) Command to run for the MCP server.
-- `config` (String, Deprecated) Deprecated JSON-encoded MCP server configuration. Use structured attributes instead.
+- `config` (String, Deprecated) Deprecated JSON-encoded MCP server configuration. Use structured attributes instead. Cannot be used together with the structured configuration attributes. Use one approach or the other.
 - `description` (String) Human-readable description of the MCP server.
 - `env` (Attributes List) Environment variables for the MCP server process. (see [below for nested schema](#nestedatt--env))
 - `heartbeat_interval_ms` (Number) Heartbeat interval in milliseconds.
@@ -56,6 +56,8 @@ resource "agyn_mcp_server" "example" {
 
 <a id="nestedatt--env"></a>
 ### Nested Schema for `env`
+
+Exactly one of `value` or `value_ref` must be specified.
 
 Required:
 

--- a/docs/resources/memory_bucket.md
+++ b/docs/resources/memory_bucket.md
@@ -27,9 +27,9 @@ resource "agyn_memory_bucket" "example" {
 ### Optional
 
 - `collection_prefix` (String) Collection prefix for memory entries.
-- `config` (String, Deprecated) Deprecated JSON-encoded memory bucket configuration. Use structured attributes instead.
+- `config` (String, Deprecated) Deprecated JSON-encoded memory bucket configuration. Use structured attributes instead. Cannot be used together with the structured configuration attributes. Use one approach or the other.
 - `description` (String) Human-readable description of the memory bucket.
-- `scope` (String) Scope for the memory bucket (global or perThread).
+- `scope` (String) Scope for the memory bucket. Must be one of `global` or `perThread`.
 - `title` (String) Human-readable title of the memory bucket.
 
 ### Read-Only

--- a/docs/resources/tool.md
+++ b/docs/resources/tool.md
@@ -8,6 +8,8 @@ description: |-
 
 # agyn_tool (Resource)
 
+~> **Deprecated:** The `agyn_tool` resource is deprecated and will be removed in a future release.
+
 Manages an Agyn tool.
 
 ## Example Usage

--- a/docs/resources/workspace_configuration.md
+++ b/docs/resources/workspace_configuration.md
@@ -45,7 +45,7 @@ resource "agyn_workspace_configuration" "example" {
 
 ### Optional
 
-- `config` (String, Deprecated) Deprecated JSON-encoded workspace configuration. Use structured attributes instead.
+- `config` (String, Deprecated) Deprecated JSON-encoded workspace configuration. Use structured attributes instead. Cannot be used together with the structured configuration attributes. Use one approach or the other.
 - `cpu_limit` (String) CPU limit for the workspace (string or number as a string).
 - `description` (String) Human-readable description of the workspace configuration.
 - `enable_dind` (Boolean) Whether to enable Docker-in-Docker.
@@ -54,7 +54,7 @@ resource "agyn_workspace_configuration" "example" {
 - `initial_script` (String) Initial script to run in the workspace.
 - `memory_limit` (String) Memory limit for the workspace (string or number as a string).
 - `nix` (String) Nix configuration as JSON.
-- `platform` (String) Platform selection (auto, linux/amd64, linux/arm64).
+- `platform` (String) Platform selection. Must be one of `auto`, `linux/amd64`, or `linux/arm64`.
 - `title` (String) Human-readable title of the workspace configuration.
 - `ttl_seconds` (Number) Time-to-live in seconds for the workspace.
 - `volumes` (Attributes) Workspace volume configuration. (see [below for nested schema](#nestedatt--volumes))
@@ -65,6 +65,8 @@ resource "agyn_workspace_configuration" "example" {
 
 <a id="nestedatt--env"></a>
 ### Nested Schema for `env`
+
+Exactly one of `value` or `value_ref` must be specified.
 
 Required:
 


### PR DESCRIPTION
## Summary
- add deprecation notice for agyn_tool docs
- document config vs typed attribute exclusivity and env constraints
- clarify platform and scope valid values

## Testing
- go vet ./...
- go test ./...

Closes #16.