### PR TITLE
Append team API path in provider

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,6 +22,8 @@ type agynProvider struct {
 	commit  string
 }
 
+const teamAPIPath = "/team/v1"
+
 func New(version, commit string) func() provider.Provider {
 	return func() provider.Provider { return &agynProvider{version: version, commit: commit} }
 }
@@ -59,12 +61,7 @@ func (p *agynProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	}
 
 	httpClient := &http.Client{Timeout: 30 * time.Second}
-
-	baseURL := strings.TrimSuffix(data.APIURL.ValueString(), "/")
-	apiURL := baseURL
-	if !strings.HasSuffix(baseURL, "/team/v1") {
-		apiURL = baseURL + "/team/v1"
-	}
+	apiURL := buildTeamAPIURL(data.APIURL.ValueString())
 
 	client, err := teamapi.NewClient(teamapi.Config{
 		BaseURL:    apiURL,
@@ -77,6 +74,10 @@ func (p *agynProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 
 	resp.DataSourceData = client
 	resp.ResourceData = client
+}
+
+func buildTeamAPIURL(baseURL string) string {
+	return strings.TrimSuffix(baseURL, "/") + teamAPIPath
 }
 
 func (p *agynProvider) Resources(_ context.Context) []func() resource.Resource {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -20,3 +20,43 @@ func testAccPreCheck(t *testing.T) {
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 	"agyn": providerserver.NewProtocol6WithError(New("test", "test")()),
 }
+
+func TestBuildTeamAPIURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{
+			name:    "no trailing slash",
+			baseURL: "https://gateway.example.com",
+			want:    "https://gateway.example.com" + teamAPIPath,
+		},
+		{
+			name:    "trailing slash",
+			baseURL: "https://gateway.example.com/",
+			want:    "https://gateway.example.com" + teamAPIPath,
+		},
+		{
+			name:    "already includes path",
+			baseURL: "https://gateway.example.com" + teamAPIPath,
+			want:    "https://gateway.example.com" + teamAPIPath + teamAPIPath,
+		},
+		{
+			name:    "path with trailing slash",
+			baseURL: "https://gateway.example.com" + teamAPIPath + "/",
+			want:    "https://gateway.example.com" + teamAPIPath + teamAPIPath,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			if got := buildTeamAPIURL(test.baseURL); got != test.want {
+				t.Fatalf("buildTeamAPIURL(%q) = %q, want %q", test.baseURL, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- append /team/v1 to the configured gateway base URL before creating the API client
- keep provider validation flow intact while adjusting the base URL

## Testing
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go build ./...

Refs #18