### PR TITLE
fix(graph): upsert missing nodes

### DIFF
--- a/internal/resources/attachment_resource.go
+++ b/internal/resources/attachment_resource.go
@@ -287,7 +287,9 @@ func (r *attachmentResource) createGraphAttachment(ctx context.Context, kind, so
 		Target:       apiTargetID,
 		TargetHandle: mapping.TargetHandle,
 	}
-	if err := r.client.UpsertGraphEdge(ctx, edge); err != nil {
+	sourceHint := teamapi.GraphNodeHint{ID: apiSourceID, Template: mapping.SourceTemplate}
+	targetHint := teamapi.GraphNodeHint{ID: apiTargetID, Template: mapping.TargetTemplate}
+	if err := r.client.UpsertGraphEdgeWithNodes(ctx, edge, sourceHint, targetHint); err != nil {
 		return nil, err
 	}
 
@@ -350,6 +352,11 @@ const (
 	graphMcpServerTargetType         = "mcpServer"
 	graphMemoryBucketSourceType      = "memoryBucket"
 	graphMcpServerSourceType         = "mcpServer"
+	graphAgentTemplate               = "agent"
+	graphToolTemplate                = "tool"
+	graphWorkspaceTemplate           = "workspaceConfiguration"
+	graphMcpServerTemplate           = "mcpServer"
+	graphMemoryBucketTemplate        = "memoryBucket"
 )
 
 type graphAttachmentMapping struct {
@@ -357,45 +364,59 @@ type graphAttachmentMapping struct {
 	TargetHandle     string
 	SourceType       string
 	TargetType       string
+	SourceTemplate   string
+	TargetTemplate   string
 	SwapSourceTarget bool
 }
 
 var graphAttachmentMappings = map[string]graphAttachmentMapping{
 	agentToolAttachmentKind: {
-		SourceHandle: graphAgentToolsSourceHandle,
-		TargetHandle: graphSelfHandle,
-		SourceType:   graphAgentSourceType,
-		TargetType:   graphToolTargetType,
+		SourceHandle:   graphAgentToolsSourceHandle,
+		TargetHandle:   graphSelfHandle,
+		SourceType:     graphAgentSourceType,
+		TargetType:     graphToolTargetType,
+		SourceTemplate: graphAgentTemplate,
+		TargetTemplate: graphToolTemplate,
 	},
 	agentMcpServerAttachmentKind: {
-		SourceHandle: graphAgentMcpSourceHandle,
-		TargetHandle: graphSelfHandle,
-		SourceType:   graphAgentSourceType,
-		TargetType:   graphMcpServerTargetType,
+		SourceHandle:   graphAgentMcpSourceHandle,
+		TargetHandle:   graphSelfHandle,
+		SourceType:     graphAgentSourceType,
+		TargetType:     graphMcpServerTargetType,
+		SourceTemplate: graphAgentTemplate,
+		TargetTemplate: graphMcpServerTemplate,
 	},
 	mcpServerWorkspaceAttachmentKind: {
-		SourceHandle: graphWorkspaceHandle,
-		TargetHandle: graphSelfHandle,
-		SourceType:   graphMcpServerSourceType,
-		TargetType:   graphWorkspaceSourceType,
+		SourceHandle:   graphWorkspaceHandle,
+		TargetHandle:   graphSelfHandle,
+		SourceType:     graphMcpServerSourceType,
+		TargetType:     graphWorkspaceSourceType,
+		SourceTemplate: graphMcpServerTemplate,
+		TargetTemplate: graphWorkspaceTemplate,
 	},
 	workspaceToolAttachmentKind: {
-		SourceHandle: graphSelfHandle,
-		TargetHandle: graphWorkspaceHandle,
-		SourceType:   graphWorkspaceSourceType,
-		TargetType:   graphToolTargetType,
+		SourceHandle:   graphSelfHandle,
+		TargetHandle:   graphWorkspaceHandle,
+		SourceType:     graphWorkspaceSourceType,
+		TargetType:     graphToolTargetType,
+		SourceTemplate: graphWorkspaceTemplate,
+		TargetTemplate: graphToolTemplate,
 	},
 	memoryBucketToolAttachmentKind: {
-		SourceHandle: graphSelfHandle,
-		TargetHandle: graphMemoryHandle,
-		SourceType:   graphMemoryBucketSourceType,
-		TargetType:   graphToolTargetType,
+		SourceHandle:   graphSelfHandle,
+		TargetHandle:   graphMemoryHandle,
+		SourceType:     graphMemoryBucketSourceType,
+		TargetType:     graphToolTargetType,
+		SourceTemplate: graphMemoryBucketTemplate,
+		TargetTemplate: graphToolTemplate,
 	},
 	toolAgentAttachmentKind: {
-		SourceHandle: graphToolAgentSourceHandle,
-		TargetHandle: graphSelfHandle,
-		SourceType:   graphToolTargetType,
-		TargetType:   graphAgentSourceType,
+		SourceHandle:   graphToolAgentSourceHandle,
+		TargetHandle:   graphSelfHandle,
+		SourceType:     graphToolTargetType,
+		TargetType:     graphAgentSourceType,
+		SourceTemplate: graphToolTemplate,
+		TargetTemplate: graphAgentTemplate,
 	},
 }
 

--- a/internal/teamapi/graph.go
+++ b/internal/teamapi/graph.go
@@ -35,6 +35,11 @@ type GraphNodePosition struct {
 	Y float64 `json:"y"`
 }
 
+type GraphNodeHint struct {
+	ID       string
+	Template string
+}
+
 type GraphEdge struct {
 	ID           string `json:"id,omitempty"`
 	Source       string `json:"source"`
@@ -162,6 +167,40 @@ func (c *Client) FindGraphEdge(ctx context.Context, edgeID string) (*GraphEdge, 
 		}
 	}
 	return nil, ErrGraphEdgeNotFound
+}
+
+func (c *Client) UpsertGraphEdgeWithNodes(ctx context.Context, edge GraphEdge, sourceHint, targetHint GraphNodeHint) error {
+	if edge.ID == "" {
+		return fmt.Errorf("graph edge id is required")
+	}
+
+	return withConflictRetryNoResult(ctx, "upsert graph edge", func() error {
+		graph, err := c.GetGraph(ctx)
+		if err != nil {
+			return err
+		}
+
+		updated := false
+		if !graphHasNode(graph.Nodes, edge.Source) {
+			graph.Nodes = append(graph.Nodes, GraphNode{ID: sourceHint.ID, Template: sourceHint.Template})
+			updated = true
+		}
+		if !graphHasNode(graph.Nodes, edge.Target) {
+			graph.Nodes = append(graph.Nodes, GraphNode{ID: targetHint.ID, Template: targetHint.Template})
+			updated = true
+		}
+		if graphEdgeIndex(graph.Edges, edge.ID) == -1 {
+			graph.Edges = append(graph.Edges, edge)
+			updated = true
+		}
+
+		if !updated {
+			return nil
+		}
+
+		_, err = c.UpsertGraph(ctx, graphUpsertRequest(graph))
+		return err
+	})
 }
 
 func (c *Client) UpsertGraphEdge(ctx context.Context, edge GraphEdge) error {

--- a/internal/teamapi/graph_test.go
+++ b/internal/teamapi/graph_test.go
@@ -169,6 +169,252 @@ func TestUpsertGraphEdgeRetriesOnConflict(t *testing.T) {
 	}
 }
 
+func TestUpsertGraphEdgeWithNodesCreatesNodes(t *testing.T) {
+	edge := GraphEdge{
+		ID:           "edge-1",
+		Source:       "source-1",
+		SourceHandle: "source-handle",
+		Target:       "target-1",
+		TargetHandle: "target-handle",
+	}
+	sourceHint := GraphNodeHint{ID: edge.Source, Template: "agent"}
+	targetHint := GraphNodeHint{ID: edge.Target, Template: "tool"}
+	graph := Graph{
+		Name:    "main",
+		Version: 1,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.Path != "/api/graph" {
+				t.Fatalf("expected path /api/graph, got %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(graph); err != nil {
+				t.Fatalf("failed to encode graph response: %v", err)
+			}
+		case http.MethodPost:
+			if r.URL.Path != "/api/graph" {
+				t.Fatalf("expected path /api/graph, got %s", r.URL.Path)
+			}
+			var payload GraphUpsertRequest
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode graph request: %v", err)
+			}
+			if len(payload.Nodes) != 2 {
+				t.Fatalf("expected 2 nodes, got %d", len(payload.Nodes))
+			}
+			sourceNode, ok := findGraphNode(payload.Nodes, sourceHint.ID)
+			if !ok {
+				t.Fatalf("expected source node %s to be included", sourceHint.ID)
+			}
+			if sourceNode.Template != sourceHint.Template {
+				t.Fatalf("expected source node template %s, got %s", sourceHint.Template, sourceNode.Template)
+			}
+			targetNode, ok := findGraphNode(payload.Nodes, targetHint.ID)
+			if !ok {
+				t.Fatalf("expected target node %s to be included", targetHint.ID)
+			}
+			if targetNode.Template != targetHint.Template {
+				t.Fatalf("expected target node template %s, got %s", targetHint.Template, targetNode.Template)
+			}
+			if len(payload.Edges) != 1 {
+				t.Fatalf("expected 1 edge, got %d", len(payload.Edges))
+			}
+			if payload.Edges[0] != edge {
+				t.Fatalf("unexpected edge payload: %+v", payload.Edges[0])
+			}
+
+			graphResponse := graph
+			graphResponse.Nodes = payload.Nodes
+			graphResponse.Edges = payload.Edges
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(graphResponse); err != nil {
+				t.Fatalf("failed to encode graph response: %v", err)
+			}
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	if err := client.UpsertGraphEdgeWithNodes(context.Background(), edge, sourceHint, targetHint); err != nil {
+		t.Fatalf("UpsertGraphEdgeWithNodes returned error: %v", err)
+	}
+}
+
+func TestUpsertGraphEdgeWithNodesSkipsExistingNodes(t *testing.T) {
+	edge := GraphEdge{
+		ID:           "edge-1",
+		Source:       "source-1",
+		SourceHandle: "source-handle",
+		Target:       "target-1",
+		TargetHandle: "target-handle",
+	}
+	sourceHint := GraphNodeHint{ID: edge.Source, Template: "agent"}
+	targetHint := GraphNodeHint{ID: edge.Target, Template: "tool"}
+	graph := Graph{
+		Name:    "main",
+		Version: 1,
+		Nodes: []GraphNode{
+			{ID: edge.Source, Template: "existing-source"},
+			{ID: edge.Target, Template: "existing-target"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.Path != "/api/graph" {
+				t.Fatalf("expected path /api/graph, got %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(graph); err != nil {
+				t.Fatalf("failed to encode graph response: %v", err)
+			}
+		case http.MethodPost:
+			if r.URL.Path != "/api/graph" {
+				t.Fatalf("expected path /api/graph, got %s", r.URL.Path)
+			}
+			var payload GraphUpsertRequest
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode graph request: %v", err)
+			}
+			if len(payload.Nodes) != 2 {
+				t.Fatalf("expected 2 nodes, got %d", len(payload.Nodes))
+			}
+			sourceNode, ok := findGraphNode(payload.Nodes, edge.Source)
+			if !ok {
+				t.Fatalf("expected source node %s to be included", edge.Source)
+			}
+			if sourceNode.Template != "existing-source" {
+				t.Fatalf("expected existing source node template, got %s", sourceNode.Template)
+			}
+			targetNode, ok := findGraphNode(payload.Nodes, edge.Target)
+			if !ok {
+				t.Fatalf("expected target node %s to be included", edge.Target)
+			}
+			if targetNode.Template != "existing-target" {
+				t.Fatalf("expected existing target node template, got %s", targetNode.Template)
+			}
+			if len(payload.Edges) != 1 {
+				t.Fatalf("expected 1 edge, got %d", len(payload.Edges))
+			}
+			if payload.Edges[0] != edge {
+				t.Fatalf("unexpected edge payload: %+v", payload.Edges[0])
+			}
+
+			graphResponse := graph
+			graphResponse.Edges = payload.Edges
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(graphResponse); err != nil {
+				t.Fatalf("failed to encode graph response: %v", err)
+			}
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	if err := client.UpsertGraphEdgeWithNodes(context.Background(), edge, sourceHint, targetHint); err != nil {
+		t.Fatalf("UpsertGraphEdgeWithNodes returned error: %v", err)
+	}
+}
+
+func TestUpsertGraphEdgeWithNodesPartialNodeCreation(t *testing.T) {
+	edge := GraphEdge{
+		ID:           "edge-1",
+		Source:       "source-1",
+		SourceHandle: "source-handle",
+		Target:       "target-1",
+		TargetHandle: "target-handle",
+	}
+	sourceHint := GraphNodeHint{ID: edge.Source, Template: "agent"}
+	targetHint := GraphNodeHint{ID: edge.Target, Template: "tool"}
+	graph := Graph{
+		Name:    "main",
+		Version: 1,
+		Nodes: []GraphNode{
+			{ID: edge.Source, Template: "existing-source"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.Path != "/api/graph" {
+				t.Fatalf("expected path /api/graph, got %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(graph); err != nil {
+				t.Fatalf("failed to encode graph response: %v", err)
+			}
+		case http.MethodPost:
+			if r.URL.Path != "/api/graph" {
+				t.Fatalf("expected path /api/graph, got %s", r.URL.Path)
+			}
+			var payload GraphUpsertRequest
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("failed to decode graph request: %v", err)
+			}
+			if len(payload.Nodes) != 2 {
+				t.Fatalf("expected 2 nodes, got %d", len(payload.Nodes))
+			}
+			sourceNode, ok := findGraphNode(payload.Nodes, edge.Source)
+			if !ok {
+				t.Fatalf("expected source node %s to be included", edge.Source)
+			}
+			if sourceNode.Template != "existing-source" {
+				t.Fatalf("expected existing source node template, got %s", sourceNode.Template)
+			}
+			targetNode, ok := findGraphNode(payload.Nodes, edge.Target)
+			if !ok {
+				t.Fatalf("expected target node %s to be included", edge.Target)
+			}
+			if targetNode.Template != targetHint.Template {
+				t.Fatalf("expected target node template %s, got %s", targetHint.Template, targetNode.Template)
+			}
+			if len(payload.Edges) != 1 {
+				t.Fatalf("expected 1 edge, got %d", len(payload.Edges))
+			}
+			if payload.Edges[0] != edge {
+				t.Fatalf("unexpected edge payload: %+v", payload.Edges[0])
+			}
+
+			graphResponse := graph
+			graphResponse.Nodes = payload.Nodes
+			graphResponse.Edges = payload.Edges
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(graphResponse); err != nil {
+				t.Fatalf("failed to encode graph response: %v", err)
+			}
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	if err := client.UpsertGraphEdgeWithNodes(context.Background(), edge, sourceHint, targetHint); err != nil {
+		t.Fatalf("UpsertGraphEdgeWithNodes returned error: %v", err)
+	}
+}
+
 func TestDeleteGraphEdgeRetriesOnConflict(t *testing.T) {
 	edge := GraphEdge{
 		ID:           "edge-1",
@@ -244,4 +490,13 @@ func TestDeleteGraphEdgeRetriesOnConflict(t *testing.T) {
 	if getCount != conflictRetryCount {
 		t.Fatalf("expected %d GET attempts, got %d", conflictRetryCount, getCount)
 	}
+}
+
+func findGraphNode(nodes []GraphNode, id string) (GraphNode, bool) {
+	for _, node := range nodes {
+		if node.ID == id {
+			return node, true
+		}
+	}
+	return GraphNode{}, false
 }


### PR DESCRIPTION
## Summary
- add graph node hints and upsert edges with node creation
- include templates in graph attachment mappings and use new edge upsert
- cover graph edge/node upsert scenarios with tests

## Testing
- go vet ./...
- go test ./...

Refs #20