### PR TITLE
fix(provider): add trailing slash

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -77,7 +77,7 @@ func (p *agynProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 }
 
 func buildTeamAPIURL(baseURL string) string {
-	return strings.TrimSuffix(baseURL, "/") + teamAPIPath
+	return strings.TrimSuffix(baseURL, "/") + teamAPIPath + "/"
 }
 
 func (p *agynProvider) Resources(_ context.Context) []func() resource.Resource {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -32,22 +32,22 @@ func TestBuildTeamAPIURL(t *testing.T) {
 		{
 			name:    "no trailing slash",
 			baseURL: "https://gateway.example.com",
-			want:    "https://gateway.example.com" + teamAPIPath,
+			want:    "https://gateway.example.com" + teamAPIPath + "/",
 		},
 		{
 			name:    "trailing slash",
 			baseURL: "https://gateway.example.com/",
-			want:    "https://gateway.example.com" + teamAPIPath,
+			want:    "https://gateway.example.com" + teamAPIPath + "/",
 		},
 		{
 			name:    "already includes path",
 			baseURL: "https://gateway.example.com" + teamAPIPath,
-			want:    "https://gateway.example.com" + teamAPIPath + teamAPIPath,
+			want:    "https://gateway.example.com" + teamAPIPath + teamAPIPath + "/",
 		},
 		{
 			name:    "path with trailing slash",
 			baseURL: "https://gateway.example.com" + teamAPIPath + "/",
-			want:    "https://gateway.example.com" + teamAPIPath + teamAPIPath,
+			want:    "https://gateway.example.com" + teamAPIPath + teamAPIPath + "/",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- ensure buildTeamAPIURL appends trailing slash for team API base
- update provider URL tests to expect trailing slash

## Testing
- go vet ./...
- go test ./...

Refs #24