### PR TITLE
test(runner): adjust org replace check

### DIFF
--- a/internal/provider/resource_runner_test.go
+++ b/internal/provider/resource_runner_test.go
@@ -85,12 +85,10 @@ func TestAccAgynRunner_organizationIDRequiresReplace(t *testing.T) {
 			{
 				Config: testAccAgynRunnerConfigWithOrganizationID(name, updatedOrganizationID),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PostApplyPreRefresh: []plancheck.PlanCheck{
+					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("agyn_runner.test", plancheck.ResourceActionReplace),
 					},
 				},
-				ExpectNonEmptyPlan: true,
-				PlanOnly:           true,
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- move organization_id replace plan check to PreApply
- drop PlanOnly/ExpectNonEmptyPlan so PreApply runs

## Testing
- go build ./...
- go vet ./...
- go test ./...

#41