### PR TITLE
Add organization_id to image pull secret

### DIFF
--- a/examples/resources/agyn_image_pull_secret/resource.tf
+++ b/examples/resources/agyn_image_pull_secret/resource.tf
@@ -1,4 +1,9 @@
+resource "agyn_organization" "example" {
+  name = "example-org"
+}
+
 resource "agyn_image_pull_secret" "example" {
+  organization_id = agyn_organization.example.id
   description = "Example image pull secret."
   registry    = "registry.example.com"
   username    = "registry-user"

--- a/internal/provider/resource_image_pull_secret_test.go
+++ b/internal/provider/resource_image_pull_secret_test.go
@@ -4,20 +4,23 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccAgynImagePullSecret_basic(t *testing.T) {
+	organizationName := acctest.RandomWithPrefix("tf-acc-org")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccOrganizationPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynImagePullSecretConfig("Terraform acceptance image pull secret", "registry.example.com", "registry-user", "registry-password"),
+				Config: testAccAgynImagePullSecretConfig(organizationName, "Terraform acceptance image pull secret", "registry.example.com", "registry-user", "registry-password"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_image_pull_secret.test", "description", "Terraform acceptance image pull secret"),
 					resource.TestCheckResourceAttr("agyn_image_pull_secret.test", "registry", "registry.example.com"),
 					resource.TestCheckResourceAttr("agyn_image_pull_secret.test", "username", "registry-user"),
+					resource.TestCheckResourceAttrSet("agyn_image_pull_secret.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_image_pull_secret.test", "password"),
 					resource.TestCheckResourceAttrSet("agyn_image_pull_secret.test", "id"),
 				),
@@ -27,26 +30,29 @@ func TestAccAgynImagePullSecret_basic(t *testing.T) {
 }
 
 func TestAccAgynImagePullSecret_update(t *testing.T) {
+	organizationName := acctest.RandomWithPrefix("tf-acc-org")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccOrganizationPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynImagePullSecretConfig("Terraform acceptance image pull secret", "registry.example.com", "registry-user", "registry-password"),
+				Config: testAccAgynImagePullSecretConfig(organizationName, "Terraform acceptance image pull secret", "registry.example.com", "registry-user", "registry-password"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_image_pull_secret.test", "description", "Terraform acceptance image pull secret"),
 					resource.TestCheckResourceAttr("agyn_image_pull_secret.test", "registry", "registry.example.com"),
 					resource.TestCheckResourceAttr("agyn_image_pull_secret.test", "username", "registry-user"),
+					resource.TestCheckResourceAttrSet("agyn_image_pull_secret.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_image_pull_secret.test", "password"),
 					resource.TestCheckResourceAttrSet("agyn_image_pull_secret.test", "id"),
 				),
 			},
 			{
-				Config: testAccAgynImagePullSecretConfig("Terraform acceptance image pull secret updated", "registry-updated.example.com", "registry-user-updated", "registry-password-updated"),
+				Config: testAccAgynImagePullSecretConfig(organizationName, "Terraform acceptance image pull secret updated", "registry-updated.example.com", "registry-user-updated", "registry-password-updated"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_image_pull_secret.test", "description", "Terraform acceptance image pull secret updated"),
 					resource.TestCheckResourceAttr("agyn_image_pull_secret.test", "registry", "registry-updated.example.com"),
 					resource.TestCheckResourceAttr("agyn_image_pull_secret.test", "username", "registry-user-updated"),
+					resource.TestCheckResourceAttrSet("agyn_image_pull_secret.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_image_pull_secret.test", "password"),
 					resource.TestCheckResourceAttrSet("agyn_image_pull_secret.test", "id"),
 				),
@@ -56,32 +62,38 @@ func TestAccAgynImagePullSecret_update(t *testing.T) {
 }
 
 func TestAccAgynImagePullSecret_import(t *testing.T) {
+	organizationName := acctest.RandomWithPrefix("tf-acc-org")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccOrganizationPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynImagePullSecretConfig("Terraform acceptance image pull secret", "registry.example.com", "registry-user", "registry-password"),
+				Config: testAccAgynImagePullSecretConfig(organizationName, "Terraform acceptance image pull secret", "registry.example.com", "registry-user", "registry-password"),
 			},
 			{
 				ResourceName:            "agyn_image_pull_secret.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
+				ImportStateVerifyIgnore: []string{"organization_id", "password"},
 			},
 		},
 	})
 }
 
-func testAccAgynImagePullSecretConfig(description, registry, username, password string) string {
+func testAccAgynImagePullSecretConfig(organizationName, description, registry, username, password string) string {
 	return fmt.Sprintf(`
 %s
 
+resource "agyn_organization" "test" {
+	  name = %q
+}
+
 resource "agyn_image_pull_secret" "test" {
+	  organization_id = agyn_organization.test.id
 	  description = %q
 	  registry    = %q
 	  username    = %q
 	  password    = %q
 }
-`, testAccProviderConfig(), description, registry, username, password)
+`, testAccProviderConfig(), organizationName, description, registry, username, password)
 }

--- a/internal/resources/image_pull_secret_resource.go
+++ b/internal/resources/image_pull_secret_resource.go
@@ -26,6 +26,7 @@ var _ resource.ResourceWithImportState = &imagePullSecretResource{}
 
 type imagePullSecretModel struct {
 	ID                     types.String `tfsdk:"id"`
+	OrganizationID         types.String `tfsdk:"organization_id"`
 	Description            types.String `tfsdk:"description"`
 	Registry               types.String `tfsdk:"registry"`
 	Username               types.String `tfsdk:"username"`
@@ -55,6 +56,14 @@ func (r *imagePullSecretResource) Schema(_ context.Context, _ resource.SchemaReq
 				Computed:            true,
 				MarkdownDescription: "UUID identifier of the image pull secret.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"organization_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Organization identifier for the image pull secret.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"description": schema.StringAttribute{
 				Optional:            true,
@@ -115,9 +124,10 @@ func (r *imagePullSecretResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	input := &secretsv1.CreateImagePullSecretRequest{
-		Description: stringValue(plan.Description),
-		Registry:    plan.Registry.ValueString(),
-		Username:    plan.Username.ValueString(),
+		OrganizationId: plan.OrganizationID.ValueString(),
+		Description:    stringValue(plan.Description),
+		Registry:       plan.Registry.ValueString(),
+		Username:       plan.Username.ValueString(),
 	}
 	if setImagePullSecretCreateSource(input, plan.Password, plan.RemoteSecretProviderID, plan.RemoteSecretReference, resp) {
 		return
@@ -132,6 +142,7 @@ func (r *imagePullSecretResource) Create(ctx context.Context, req resource.Creat
 	password, remoteProviderID, remoteReference := imagePullSecretSourceState(secret, plan.Password)
 	updatedState := imagePullSecretModel{
 		ID:                     types.StringValue(secret.Meta.Id),
+		OrganizationID:         plan.OrganizationID,
 		Description:            optionalString(secret.Description),
 		Registry:               types.StringValue(secret.Registry),
 		Username:               types.StringValue(secret.Username),
@@ -209,6 +220,7 @@ func (r *imagePullSecretResource) Update(ctx context.Context, req resource.Updat
 	password, remoteProviderID, remoteReference := imagePullSecretSourceState(secret, plan.Password)
 	updatedState := imagePullSecretModel{
 		ID:                     types.StringValue(secret.Meta.Id),
+		OrganizationID:         state.OrganizationID,
 		Description:            optionalString(secret.Description),
 		Registry:               types.StringValue(secret.Registry),
 		Username:               types.StringValue(secret.Username),


### PR DESCRIPTION
## Summary
- add organization_id to image pull secret resource model/schema and state
- update acceptance tests and example config for organization usage

## Testing
- buf generate
- go vet ./...
- go test ./...

#58