### PR TITLE
feat(agent): add init_image support

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: 8829d3a9fb094bce935f13bb61bde0d7
-    digest: shake256:99b8fda5a15ff92468f16ba60842ff97f04e254d2d34810ffbaac6a04878669cde1b80b4e92270e90c466dd2ed9117963408f3a34b04a522b420cadea16d5283
+    commit: b67ca28ce2c94ca1a95f27e18051641b
+    digest: shake256:fc939b54bfabac248969211ca6f70d6c4efe48c6e971644470c1a1eb2e49719208d270ce7b7319bace0ac279a1a8b2e842b146204a3d2600ab974c807c727ea3
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/examples/resources/agyn_agent/resource.tf
+++ b/examples/resources/agyn_agent/resource.tf
@@ -6,4 +6,5 @@ resource "agyn_agent" "example" {
   model         = "gpt-4o"
   system_prompt = "Assist with workspace automation."
   when_busy     = "wait"
+  init_image    = "ghcr.io/agynio/agent-init-codex:v1.0.0"
 }

--- a/internal/provider/acc_helpers_test.go
+++ b/internal/provider/acc_helpers_test.go
@@ -13,6 +13,7 @@ resource "agyn_agent" "test" {
 	  role        = %q
 	  model       = %q
 	  image       = %q
+	  init_image  = %q
 }
-`, name, description, role, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"))
+`, name, description, role, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"), os.Getenv("AGYN_AGENT_IMAGE"))
 }

--- a/internal/provider/acc_helpers_test.go
+++ b/internal/provider/acc_helpers_test.go
@@ -15,5 +15,5 @@ resource "agyn_agent" "test" {
 	  image       = %q
 	  init_image  = %q
 }
-`, name, description, role, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"), os.Getenv("AGYN_AGENT_IMAGE"))
+`, name, description, role, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"), os.Getenv("AGYN_AGENT_INIT_IMAGE"))
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -21,6 +21,9 @@ func testAccPreCheck(t *testing.T) {
 	if os.Getenv("AGYN_AGENT_IMAGE") == "" {
 		t.Skip("AGYN_AGENT_IMAGE must be set for acceptance tests")
 	}
+	if os.Getenv("AGYN_AGENT_INIT_IMAGE") == "" {
+		t.Skip("AGYN_AGENT_INIT_IMAGE must be set for acceptance tests")
+	}
 }
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/internal/provider/resource_agent_test.go
+++ b/internal/provider/resource_agent_test.go
@@ -23,7 +23,7 @@ func TestAccAgynAgent_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("agyn_agent.test", "name", resourceName),
 					resource.TestCheckResourceAttr("agyn_agent.test", "description", "Terraform acceptance agent"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "role", "Terraform acceptance role"),
-					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_IMAGE")),
+					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_INIT_IMAGE")),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "model"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "image"),
@@ -48,7 +48,7 @@ func TestAccAgynAgent_update(t *testing.T) {
 					resource.TestCheckResourceAttr("agyn_agent.test", "name", resourceName),
 					resource.TestCheckResourceAttr("agyn_agent.test", "description", "Terraform acceptance agent"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "role", "Terraform acceptance role"),
-					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_IMAGE")),
+					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_INIT_IMAGE")),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "model"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "image"),
@@ -61,7 +61,7 @@ func TestAccAgynAgent_update(t *testing.T) {
 					resource.TestCheckResourceAttr("agyn_agent.test", "name", updatedName),
 					resource.TestCheckResourceAttr("agyn_agent.test", "description", "Terraform acceptance agent updated"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "role", "Terraform acceptance role updated"),
-					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_IMAGE")),
+					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_INIT_IMAGE")),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "model"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "image"),
@@ -130,7 +130,7 @@ resource "agyn_agent" "test" {
 	  image       = %q
 	  init_image  = %q
 }
-`, testAccProviderConfig(), organizationName, title, description, role, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"), os.Getenv("AGYN_AGENT_IMAGE"))
+`, testAccProviderConfig(), organizationName, title, description, role, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"), os.Getenv("AGYN_AGENT_INIT_IMAGE"))
 }
 
 func testAccAgynAgentInvalidConfig(organizationName string) string {
@@ -150,5 +150,5 @@ resource "agyn_agent" "test" {
 	  init_image    = %q
 	  configuration = "{invalid"
 }
-`, testAccProviderConfig(), organizationName, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"), os.Getenv("AGYN_AGENT_IMAGE"))
+`, testAccProviderConfig(), organizationName, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"), os.Getenv("AGYN_AGENT_INIT_IMAGE"))
 }

--- a/internal/provider/resource_agent_test.go
+++ b/internal/provider/resource_agent_test.go
@@ -23,6 +23,7 @@ func TestAccAgynAgent_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("agyn_agent.test", "name", resourceName),
 					resource.TestCheckResourceAttr("agyn_agent.test", "description", "Terraform acceptance agent"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "role", "Terraform acceptance role"),
+					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_IMAGE")),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "model"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "image"),
@@ -47,6 +48,7 @@ func TestAccAgynAgent_update(t *testing.T) {
 					resource.TestCheckResourceAttr("agyn_agent.test", "name", resourceName),
 					resource.TestCheckResourceAttr("agyn_agent.test", "description", "Terraform acceptance agent"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "role", "Terraform acceptance role"),
+					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_IMAGE")),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "model"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "image"),
@@ -59,6 +61,7 @@ func TestAccAgynAgent_update(t *testing.T) {
 					resource.TestCheckResourceAttr("agyn_agent.test", "name", updatedName),
 					resource.TestCheckResourceAttr("agyn_agent.test", "description", "Terraform acceptance agent updated"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "role", "Terraform acceptance role updated"),
+					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_IMAGE")),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "model"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "image"),
@@ -125,8 +128,9 @@ resource "agyn_agent" "test" {
 	  role        = %q
 	  model       = %q
 	  image       = %q
+	  init_image  = %q
 }
-`, testAccProviderConfig(), organizationName, title, description, role, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"))
+`, testAccProviderConfig(), organizationName, title, description, role, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"), os.Getenv("AGYN_AGENT_IMAGE"))
 }
 
 func testAccAgynAgentInvalidConfig(organizationName string) string {
@@ -143,7 +147,8 @@ resource "agyn_agent" "test" {
 	  role          = "invalid"
 	  model         = %q
 	  image         = %q
+	  init_image    = %q
 	  configuration = "{invalid"
 }
-`, testAccProviderConfig(), organizationName, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"))
+`, testAccProviderConfig(), organizationName, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"), os.Getenv("AGYN_AGENT_IMAGE"))
 }

--- a/internal/resources/agent_resource.go
+++ b/internal/resources/agent_resource.go
@@ -29,6 +29,7 @@ type agentModel struct {
 	Role           types.String           `tfsdk:"role"`
 	Model          types.String           `tfsdk:"model"`
 	Image          types.String           `tfsdk:"image"`
+	InitImage      types.String           `tfsdk:"init_image"`
 	Description    types.String           `tfsdk:"description"`
 	Configuration  types.String           `tfsdk:"configuration"`
 	Resources      *computeResourcesModel `tfsdk:"resources"`
@@ -69,6 +70,10 @@ func (r *agentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"image": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Container image.",
+			},
+			"init_image": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Init container image.",
 			},
 			"description": schema.StringAttribute{
 				Optional:            true,
@@ -125,6 +130,7 @@ func (r *agentResource) Create(ctx context.Context, req resource.CreateRequest, 
 		Role:           plan.Role.ValueString(),
 		Model:          plan.Model.ValueString(),
 		Image:          plan.Image.ValueString(),
+		InitImage:      plan.InitImage.ValueString(),
 		Description:    stringValue(plan.Description),
 		Configuration:  stringValue(plan.Configuration),
 		Resources:      computeResourcesFromModel(plan.Resources),
@@ -149,6 +155,7 @@ func (r *agentResource) Create(ctx context.Context, req resource.CreateRequest, 
 		Role:           types.StringValue(agent.Role),
 		Model:          types.StringValue(agent.Model),
 		Image:          types.StringValue(agent.Image),
+		InitImage:      types.StringValue(agent.InitImage),
 		Description:    optionalString(agent.Description),
 		Configuration:  configuration,
 		Resources:      computeResourcesToModel(agent.Resources),
@@ -189,6 +196,7 @@ func (r *agentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	state.Role = types.StringValue(agent.Role)
 	state.Model = types.StringValue(agent.Model)
 	state.Image = types.StringValue(agent.Image)
+	state.InitImage = types.StringValue(agent.InitImage)
 	state.OrganizationID = types.StringValue(agent.OrganizationId)
 	state.Description = optionalString(agent.Description)
 	state.Configuration = configuration
@@ -224,6 +232,7 @@ func (r *agentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		Role:          updateStringPointer(plan.Role, state.Role),
 		Model:         updateStringPointer(plan.Model, state.Model),
 		Image:         updateStringPointer(plan.Image, state.Image),
+		InitImage:     updateStringPointer(plan.InitImage, state.InitImage),
 		Description:   updateStringPointer(plan.Description, state.Description),
 		Configuration: updateStringPointer(plan.Configuration, state.Configuration),
 		Resources:     updateComputeResources(plan.Resources, state.Resources),
@@ -248,6 +257,7 @@ func (r *agentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		Role:           types.StringValue(agent.Role),
 		Model:          types.StringValue(agent.Model),
 		Image:          types.StringValue(agent.Image),
+		InitImage:      types.StringValue(agent.InitImage),
 		Description:    optionalString(agent.Description),
 		Configuration:  configuration,
 		Resources:      computeResourcesToModel(agent.Resources),


### PR DESCRIPTION
## Summary
- add init_image to the agent resource schema and API mappings
- update agent acceptance configs/helpers and example usage

## Testing
- buf generate
- go build ./...
- go vet ./...
- go test ./...

Refs #60