### PR TITLE
Avoid panic on image pull secret create

### DIFF
--- a/internal/resources/image_pull_secret_resource.go
+++ b/internal/resources/image_pull_secret_resource.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -306,9 +307,11 @@ func imagePullSecretSourceState(secret *secretsv1.ImagePullSecret, fallback type
 		}
 		remoteProviderID = types.StringValue(source.Remote.ValueProviderId)
 		remoteReference = optionalString(source.Remote.ValueReference)
-	default:
+	case nil:
 		// API does not echo sensitive source back; preserve plan value
 		password = fallback
+	default:
+		panic(fmt.Sprintf("unexpected image pull secret source type: %T", source))
 	}
 
 	return password, remoteProviderID, remoteReference

--- a/internal/resources/image_pull_secret_resource.go
+++ b/internal/resources/image_pull_secret_resource.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -308,7 +307,8 @@ func imagePullSecretSourceState(secret *secretsv1.ImagePullSecret, fallback type
 		remoteProviderID = types.StringValue(source.Remote.ValueProviderId)
 		remoteReference = optionalString(source.Remote.ValueReference)
 	default:
-		panic(fmt.Sprintf("unexpected image pull secret source type: %T", source))
+		// API does not echo sensitive source back; preserve plan value
+		password = fallback
 	}
 
 	return password, remoteProviderID, remoteReference


### PR DESCRIPTION
## Summary
- preserve plan password when API does not return image pull secret source
- remove panic on nil source in image pull secret state handling

## Testing
- buf generate
- go build ./...
- go vet ./...
- go test ./...

#62