### PR TITLE
feat(llm-provider): add protocol support

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: b67ca28ce2c94ca1a95f27e18051641b
-    digest: shake256:fc939b54bfabac248969211ca6f70d6c4efe48c6e971644470c1a1eb2e49719208d270ce7b7319bace0ac279a1a8b2e842b146204a3d2600ab974c807c727ea3
+    commit: 3f78babcf0f741578516997fa1df2258
+    digest: shake256:db3e541006986820d4a3fe910278577daa43be1c4f132b63741095df16f5e6145c4ec0c41728e4685671ed4078cde755aa973d828ef5465cfbb0db5e247cb093
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/internal/resources/llm_provider_resource.go
+++ b/internal/resources/llm_provider_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -28,6 +29,7 @@ type llmProviderModel struct {
 	ID             types.String `tfsdk:"id"`
 	OrganizationID types.String `tfsdk:"organization_id"`
 	Endpoint       types.String `tfsdk:"endpoint"`
+	Protocol       types.String `tfsdk:"protocol"`
 	AuthMethod     types.String `tfsdk:"auth_method"`
 	Token          types.String `tfsdk:"token"`
 }
@@ -56,10 +58,17 @@ func (r *llmProviderResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Required:            true,
 				MarkdownDescription: "Provider base URL.",
 			},
+			"protocol": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "LLM provider protocol.",
+				Default:             stringdefault.StaticString("responses"),
+				Validators:          []validator.String{stringvalidator.OneOf("responses", "anthropic_messages")},
+			},
 			"auth_method": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Authentication method for the provider.",
-				Validators:          []validator.String{stringvalidator.OneOf("bearer")},
+				Validators:          []validator.String{stringvalidator.OneOf("bearer", "x_api_key")},
 			},
 			"token": schema.StringAttribute{
 				Required:            true,
@@ -96,6 +105,7 @@ func (r *llmProviderResource) Create(ctx context.Context, req resource.CreateReq
 
 	input := &llmv1.CreateLLMProviderRequest{
 		Endpoint:       plan.Endpoint.ValueString(),
+		Protocol:       toProtoProtocol(plan.Protocol.ValueString()),
 		AuthMethod:     toProtoAuthMethod(plan.AuthMethod.ValueString()),
 		Token:          plan.Token.ValueString(),
 		OrganizationId: plan.OrganizationID.ValueString(),
@@ -111,6 +121,7 @@ func (r *llmProviderResource) Create(ctx context.Context, req resource.CreateReq
 		ID:             types.StringValue(provider.Meta.Id),
 		OrganizationID: types.StringValue(provider.OrganizationId),
 		Endpoint:       types.StringValue(provider.Endpoint),
+		Protocol:       types.StringValue(fromProtoProtocol(provider.Protocol)),
 		AuthMethod:     types.StringValue(fromProtoAuthMethod(provider.AuthMethod)),
 		Token:          types.StringValue(plan.Token.ValueString()),
 	}
@@ -143,6 +154,7 @@ func (r *llmProviderResource) Read(ctx context.Context, req resource.ReadRequest
 	state.ID = types.StringValue(provider.Meta.Id)
 	state.OrganizationID = types.StringValue(provider.OrganizationId)
 	state.Endpoint = types.StringValue(provider.Endpoint)
+	state.Protocol = types.StringValue(fromProtoProtocol(provider.Protocol))
 	state.AuthMethod = types.StringValue(fromProtoAuthMethod(provider.AuthMethod))
 	state.Token = preserveSensitiveString(state.Token, "")
 
@@ -166,6 +178,7 @@ func (r *llmProviderResource) Update(ctx context.Context, req resource.UpdateReq
 	input := &llmv1.UpdateLLMProviderRequest{
 		Id:         plan.ID.ValueString(),
 		Endpoint:   updateStringPointer(plan.Endpoint, state.Endpoint),
+		Protocol:   updateProtocolPointer(plan.Protocol, state.Protocol),
 		AuthMethod: updateAuthMethodPointer(plan.AuthMethod, state.AuthMethod),
 		Token:      updateStringPointer(plan.Token, state.Token),
 	}
@@ -180,6 +193,7 @@ func (r *llmProviderResource) Update(ctx context.Context, req resource.UpdateReq
 		ID:             types.StringValue(provider.Meta.Id),
 		OrganizationID: types.StringValue(provider.OrganizationId),
 		Endpoint:       types.StringValue(provider.Endpoint),
+		Protocol:       types.StringValue(fromProtoProtocol(provider.Protocol)),
 		AuthMethod:     types.StringValue(fromProtoAuthMethod(provider.AuthMethod)),
 		Token:          types.StringValue(plan.Token.ValueString()),
 	}
@@ -227,10 +241,38 @@ func updateAuthMethodPointer(plan types.String, prior types.String) *llmv1.AuthM
 	return &value
 }
 
+func updateProtocolPointer(plan types.String, prior types.String) *llmv1.Protocol {
+	if plan.IsUnknown() {
+		return nil
+	}
+	if plan.IsNull() {
+		if prior.IsNull() || prior.IsUnknown() {
+			return nil
+		}
+		value := llmv1.Protocol_PROTOCOL_UNSPECIFIED
+		return &value
+	}
+	value := toProtoProtocol(plan.ValueString())
+	return &value
+}
+
 func toProtoAuthMethod(v string) llmv1.AuthMethod {
 	switch v {
 	case "bearer":
 		return llmv1.AuthMethod_AUTH_METHOD_BEARER
+	case "x_api_key":
+		return llmv1.AuthMethod_AUTH_METHOD_X_API_KEY
+	default:
+		panic("unreachable: validated by schema")
+	}
+}
+
+func toProtoProtocol(v string) llmv1.Protocol {
+	switch v {
+	case "responses":
+		return llmv1.Protocol_PROTOCOL_RESPONSES
+	case "anthropic_messages":
+		return llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES
 	default:
 		panic("unreachable: validated by schema")
 	}
@@ -240,7 +282,20 @@ func fromProtoAuthMethod(v llmv1.AuthMethod) string {
 	switch v {
 	case llmv1.AuthMethod_AUTH_METHOD_BEARER:
 		return "bearer"
+	case llmv1.AuthMethod_AUTH_METHOD_X_API_KEY:
+		return "x_api_key"
 	default:
 		panic(fmt.Sprintf("unreachable: unexpected proto auth method %v", v))
+	}
+}
+
+func fromProtoProtocol(v llmv1.Protocol) string {
+	switch v {
+	case llmv1.Protocol_PROTOCOL_RESPONSES:
+		return "responses"
+	case llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES:
+		return "anthropic_messages"
+	default:
+		panic(fmt.Sprintf("unreachable: unexpected proto protocol %v", v))
 	}
 }

--- a/internal/resources/llm_provider_resource.go
+++ b/internal/resources/llm_provider_resource.go
@@ -61,7 +61,7 @@ func (r *llmProviderResource) Schema(_ context.Context, _ resource.SchemaRequest
 			"protocol": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				MarkdownDescription: "LLM provider protocol.",
+				MarkdownDescription: "Wire protocol the provider speaks. Must be \"responses\" or \"anthropic_messages\". Defaults to \"responses\".",
 				Default:             stringdefault.StaticString("responses"),
 				Validators:          []validator.String{stringvalidator.OneOf("responses", "anthropic_messages")},
 			},

--- a/internal/resources/llm_provider_resource_test.go
+++ b/internal/resources/llm_provider_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	llmv1 "github.com/agynio/terraform-provider-agyn/gen/agynio/api/llm/v1"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestToProtoAuthMethod(t *testing.T) {
@@ -25,9 +26,11 @@ func TestToProtoAuthMethod(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := toProtoAuthMethod(tt.input); got != tt.expected {
-			t.Fatalf("%s: expected %v, got %v", tt.name, tt.expected, got)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toProtoAuthMethod(tt.input); got != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, got)
+			}
+		})
 	}
 }
 
@@ -50,9 +53,11 @@ func TestFromProtoAuthMethod(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := fromProtoAuthMethod(tt.input); got != tt.expected {
-			t.Fatalf("%s: expected %q, got %q", tt.name, tt.expected, got)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fromProtoAuthMethod(tt.input); got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
 	}
 }
 
@@ -75,9 +80,11 @@ func TestToProtoProtocol(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := toProtoProtocol(tt.input); got != tt.expected {
-			t.Fatalf("%s: expected %v, got %v", tt.name, tt.expected, got)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toProtoProtocol(tt.input); got != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, got)
+			}
+		})
 	}
 }
 
@@ -100,8 +107,63 @@ func TestFromProtoProtocol(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := fromProtoProtocol(tt.input); got != tt.expected {
-			t.Fatalf("%s: expected %q, got %q", tt.name, tt.expected, got)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fromProtoProtocol(tt.input); got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestUpdateProtocolPointer(t *testing.T) {
+	protocolPointer := func(value llmv1.Protocol) *llmv1.Protocol {
+		return &value
+	}
+
+	tests := []struct {
+		name     string
+		plan     types.String
+		prior    types.String
+		expected *llmv1.Protocol
+	}{
+		{
+			name:     "unknown plan",
+			plan:     types.StringUnknown(),
+			prior:    types.StringValue("responses"),
+			expected: nil,
+		},
+		{
+			name:     "null plan with null prior",
+			plan:     types.StringNull(),
+			prior:    types.StringNull(),
+			expected: nil,
+		},
+		{
+			name:     "null plan with prior set",
+			plan:     types.StringNull(),
+			prior:    types.StringValue("responses"),
+			expected: protocolPointer(llmv1.Protocol_PROTOCOL_UNSPECIFIED),
+		},
+		{
+			name:     "set plan with prior set",
+			plan:     types.StringValue("responses"),
+			prior:    types.StringValue("anthropic_messages"),
+			expected: protocolPointer(llmv1.Protocol_PROTOCOL_RESPONSES),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := updateProtocolPointer(tt.plan, tt.prior)
+			if tt.expected == nil {
+				if got != nil {
+					t.Fatalf("expected nil pointer, got %v", got)
+				}
+				return
+			}
+			if got == nil || *got != *tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, got)
+			}
+		})
 	}
 }

--- a/internal/resources/llm_provider_resource_test.go
+++ b/internal/resources/llm_provider_resource_test.go
@@ -1,0 +1,107 @@
+package resources
+
+import (
+	"testing"
+
+	llmv1 "github.com/agynio/terraform-provider-agyn/gen/agynio/api/llm/v1"
+)
+
+func TestToProtoAuthMethod(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected llmv1.AuthMethod
+	}{
+		{
+			name:     "bearer",
+			input:    "bearer",
+			expected: llmv1.AuthMethod_AUTH_METHOD_BEARER,
+		},
+		{
+			name:     "x_api_key",
+			input:    "x_api_key",
+			expected: llmv1.AuthMethod_AUTH_METHOD_X_API_KEY,
+		},
+	}
+
+	for _, tt := range tests {
+		if got := toProtoAuthMethod(tt.input); got != tt.expected {
+			t.Fatalf("%s: expected %v, got %v", tt.name, tt.expected, got)
+		}
+	}
+}
+
+func TestFromProtoAuthMethod(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    llmv1.AuthMethod
+		expected string
+	}{
+		{
+			name:     "bearer",
+			input:    llmv1.AuthMethod_AUTH_METHOD_BEARER,
+			expected: "bearer",
+		},
+		{
+			name:     "x_api_key",
+			input:    llmv1.AuthMethod_AUTH_METHOD_X_API_KEY,
+			expected: "x_api_key",
+		},
+	}
+
+	for _, tt := range tests {
+		if got := fromProtoAuthMethod(tt.input); got != tt.expected {
+			t.Fatalf("%s: expected %q, got %q", tt.name, tt.expected, got)
+		}
+	}
+}
+
+func TestToProtoProtocol(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected llmv1.Protocol
+	}{
+		{
+			name:     "responses",
+			input:    "responses",
+			expected: llmv1.Protocol_PROTOCOL_RESPONSES,
+		},
+		{
+			name:     "anthropic_messages",
+			input:    "anthropic_messages",
+			expected: llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES,
+		},
+	}
+
+	for _, tt := range tests {
+		if got := toProtoProtocol(tt.input); got != tt.expected {
+			t.Fatalf("%s: expected %v, got %v", tt.name, tt.expected, got)
+		}
+	}
+}
+
+func TestFromProtoProtocol(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    llmv1.Protocol
+		expected string
+	}{
+		{
+			name:     "responses",
+			input:    llmv1.Protocol_PROTOCOL_RESPONSES,
+			expected: "responses",
+		},
+		{
+			name:     "anthropic_messages",
+			input:    llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES,
+			expected: "anthropic_messages",
+		},
+	}
+
+	for _, tt := range tests {
+		if got := fromProtoProtocol(tt.input); got != tt.expected {
+			t.Fatalf("%s: expected %q, got %q", tt.name, tt.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- align protocol attribute description with the spec
- add protocol pointer unit test coverage and subtests for conversions

## Scope note
- Acceptance tests and example updates require a live API and are deferred.

## Testing
- go vet ./...
- go test ./...

Refs #65