### PR TITLE
feat(provider): add capabilities lists

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: 22374dfebd27415e87b56f12646c5e75
-    digest: shake256:a6c86880bb2dfc9067da63cb5acb7720cad65ac97f314b82c02fdf1c952b93cb83bfad0ca4509fad735d8d4758c7ab3359b3bde5e4c79fe3b3ae42d874cdaaf0
+    commit: f3017f9d17f34204bb16b2d4965e8e58
+    digest: shake256:d7a844b0d81eb46525351d250d8b7df473f5dd907aa1b1e26273cf27fab84f0edde9844c07924e86f1f7583ed5204371aa1647f7d09165563973b0228206c086
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -25,7 +25,6 @@ resource "agyn_agent" "example" {
   model           = "gpt-4o"
   image           = "ghcr.io/agynio/agent-runtime:v1.0.0"
   init_image      = "ghcr.io/agynio/agent-init:v1.0.0"
-  capabilities    = ["docker"]
   description     = "Example agent managed by Terraform."
 }
 ```

--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -25,6 +25,7 @@ resource "agyn_agent" "example" {
   model           = "gpt-4o"
   image           = "ghcr.io/agynio/agent-runtime:v1.0.0"
   init_image      = "ghcr.io/agynio/agent-init:v1.0.0"
+  capabilities    = ["docker"]
   description     = "Example agent managed by Terraform."
 }
 ```
@@ -43,6 +44,7 @@ resource "agyn_agent" "example" {
 
 ### Optional
 
+- `capabilities` (List of String) Capabilities supported by this agent.
 - `configuration` (String) JSON-encoded agent configuration.
 - `description` (String) Human-readable description.
 - `idle_timeout` (String) Go duration string for idle timeout (for example, "30s", "5m", "1h").

--- a/docs/resources/runner.md
+++ b/docs/resources/runner.md
@@ -20,6 +20,7 @@ resource "agyn_organization" "example" {
 resource "agyn_runner" "example" {
   name            = "example-runner"
   organization_id = agyn_organization.example.id
+  capabilities    = ["docker"]
   labels = {
     region = "us-east-1"
   }
@@ -35,6 +36,7 @@ resource "agyn_runner" "example" {
 
 ### Optional
 
+- `capabilities` (List of String) Capabilities supported by this runner.
 - `labels` (Map of String) Runner labels.
 - `organization_id` (String) Organization identifier for the runner.
 

--- a/docs/resources/runner.md
+++ b/docs/resources/runner.md
@@ -20,7 +20,6 @@ resource "agyn_organization" "example" {
 resource "agyn_runner" "example" {
   name            = "example-runner"
   organization_id = agyn_organization.example.id
-  capabilities    = ["docker"]
   labels = {
     region = "us-east-1"
   }

--- a/internal/provider/acc_helpers_test.go
+++ b/internal/provider/acc_helpers_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 func testAccAgynAgentResourceBlock(name, description, role string) string {
@@ -16,4 +17,15 @@ resource "agyn_agent" "test" {
 	  init_image  = %q
 }
 `, name, description, role, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"), os.Getenv("AGYN_AGENT_INIT_IMAGE"))
+}
+
+func formatCapabilitiesLine(capabilities []string, indent string) string {
+	if len(capabilities) == 0 {
+		return ""
+	}
+	quoted := make([]string, 0, len(capabilities))
+	for _, capability := range capabilities {
+		quoted = append(quoted, fmt.Sprintf("%q", capability))
+	}
+	return fmt.Sprintf("\n%s%s", indent, fmt.Sprintf("capabilities = [%s]", strings.Join(quoted, ", ")))
 }

--- a/internal/provider/resource_agent_test.go
+++ b/internal/provider/resource_agent_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -18,12 +19,14 @@ func TestAccAgynAgent_basic(t *testing.T) {
 		PreCheck:                 func() { testAccOrganizationPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynAgentConfig(organizationName, resourceName, "Terraform acceptance agent", "Terraform acceptance role", nil),
+				Config: testAccAgynAgentConfig(organizationName, resourceName, "Terraform acceptance agent", "Terraform acceptance role", nil, []string{"docker"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_agent.test", "name", resourceName),
 					resource.TestCheckResourceAttr("agyn_agent.test", "description", "Terraform acceptance agent"),
 					resource.TestCheckNoResourceAttr("agyn_agent.test", "nickname"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "role", "Terraform acceptance role"),
+					resource.TestCheckResourceAttr("agyn_agent.test", "capabilities.#", "1"),
+					resource.TestCheckResourceAttr("agyn_agent.test", "capabilities.0", "docker"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_INIT_IMAGE")),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "model"),
@@ -46,12 +49,14 @@ func TestAccAgynAgent_update(t *testing.T) {
 		PreCheck:                 func() { testAccOrganizationPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynAgentConfig(organizationName, resourceName, "Terraform acceptance agent", "Terraform acceptance role", &nickname),
+				Config: testAccAgynAgentConfig(organizationName, resourceName, "Terraform acceptance agent", "Terraform acceptance role", &nickname, []string{"docker"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_agent.test", "name", resourceName),
 					resource.TestCheckResourceAttr("agyn_agent.test", "description", "Terraform acceptance agent"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "nickname", nickname),
 					resource.TestCheckResourceAttr("agyn_agent.test", "role", "Terraform acceptance role"),
+					resource.TestCheckResourceAttr("agyn_agent.test", "capabilities.#", "1"),
+					resource.TestCheckResourceAttr("agyn_agent.test", "capabilities.0", "docker"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_INIT_IMAGE")),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "model"),
@@ -60,12 +65,13 @@ func TestAccAgynAgent_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAgynAgentConfig(organizationName, updatedName, "Terraform acceptance agent updated", "Terraform acceptance role updated", &updatedNickname),
+				Config: testAccAgynAgentConfig(organizationName, updatedName, "Terraform acceptance agent updated", "Terraform acceptance role updated", &updatedNickname, []string{"docker", "gpu"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_agent.test", "name", updatedName),
 					resource.TestCheckResourceAttr("agyn_agent.test", "description", "Terraform acceptance agent updated"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "nickname", updatedNickname),
 					resource.TestCheckResourceAttr("agyn_agent.test", "role", "Terraform acceptance role updated"),
+					resource.TestCheckResourceAttr("agyn_agent.test", "capabilities.#", "2"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_INIT_IMAGE")),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "model"),
@@ -74,13 +80,14 @@ func TestAccAgynAgent_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAgynAgentConfig(organizationName, updatedName, "Terraform acceptance agent updated", "Terraform acceptance role updated", nil),
+				Config: testAccAgynAgentConfig(organizationName, updatedName, "Terraform acceptance agent updated", "Terraform acceptance role updated", nil, nil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_agent.test", "name", updatedName),
 					resource.TestCheckResourceAttr("agyn_agent.test", "description", "Terraform acceptance agent updated"),
 					resource.TestCheckNoResourceAttr("agyn_agent.test", "nickname"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "role", "Terraform acceptance role updated"),
 					resource.TestCheckResourceAttr("agyn_agent.test", "init_image", os.Getenv("AGYN_AGENT_INIT_IMAGE")),
+					resource.TestCheckResourceAttr("agyn_agent.test", "capabilities.#", "0"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "organization_id"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "model"),
 					resource.TestCheckResourceAttrSet("agyn_agent.test", "image"),
@@ -100,7 +107,7 @@ func TestAccAgynAgent_import(t *testing.T) {
 		PreCheck:                 func() { testAccOrganizationPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynAgentConfig(organizationName, resourceName, "Terraform acceptance agent", "Terraform acceptance role", &nickname),
+				Config: testAccAgynAgentConfig(organizationName, resourceName, "Terraform acceptance agent", "Terraform acceptance role", &nickname, []string{"docker"}),
 			},
 			{
 				ResourceName:      "agyn_agent.test",
@@ -147,10 +154,18 @@ provider "agyn" {
 `, os.Getenv("AGYN_BASE_URL"))
 }
 
-func testAccAgynAgentConfig(organizationName, title, description, role string, nickname *string) string {
+func testAccAgynAgentConfig(organizationName, title, description, role string, nickname *string, capabilities []string) string {
 	nicknameLine := ""
 	if nickname != nil {
 		nicknameLine = fmt.Sprintf("\n\t\tnickname    = %q", *nickname)
+	}
+	capabilityLine := ""
+	if len(capabilities) > 0 {
+		quoted := make([]string, 0, len(capabilities))
+		for _, capability := range capabilities {
+			quoted = append(quoted, fmt.Sprintf("%q", capability))
+		}
+		capabilityLine = fmt.Sprintf("\n\t\tcapabilities = [%s]", strings.Join(quoted, ", "))
 	}
 	return fmt.Sprintf(`
 %s
@@ -168,8 +183,9 @@ resource "agyn_agent" "test" {
 	  image       = %q
 	  init_image  = %q
 %s
+%s
 }
-`, testAccProviderConfig(), organizationName, title, description, role, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"), os.Getenv("AGYN_AGENT_INIT_IMAGE"), nicknameLine)
+`, testAccProviderConfig(), organizationName, title, description, role, os.Getenv("AGYN_MODEL_ID"), os.Getenv("AGYN_AGENT_IMAGE"), os.Getenv("AGYN_AGENT_INIT_IMAGE"), nicknameLine, capabilityLine)
 }
 
 func testAccAgynAgentInvalidConfig(organizationName string) string {

--- a/internal/provider/resource_agent_test.go
+++ b/internal/provider/resource_agent_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -159,14 +158,7 @@ func testAccAgynAgentConfig(organizationName, title, description, role string, n
 	if nickname != nil {
 		nicknameLine = fmt.Sprintf("\n\t\tnickname    = %q", *nickname)
 	}
-	capabilityLine := ""
-	if len(capabilities) > 0 {
-		quoted := make([]string, 0, len(capabilities))
-		for _, capability := range capabilities {
-			quoted = append(quoted, fmt.Sprintf("%q", capability))
-		}
-		capabilityLine = fmt.Sprintf("\n\t\tcapabilities = [%s]", strings.Join(quoted, ", "))
-	}
+	capabilityLine := formatCapabilitiesLine(capabilities, "\t\t")
 	return fmt.Sprintf(`
 %s
 

--- a/internal/provider/resource_runner_test.go
+++ b/internal/provider/resource_runner_test.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -134,14 +133,7 @@ func testAccRunnerOrgPreCheck(t *testing.T) {
 }
 
 func testAccAgynRunnerConfig(name string, capabilities []string) string {
-	capabilityLine := ""
-	if len(capabilities) > 0 {
-		quoted := make([]string, 0, len(capabilities))
-		for _, capability := range capabilities {
-			quoted = append(quoted, fmt.Sprintf("%q", capability))
-		}
-		capabilityLine = fmt.Sprintf("\n\t  capabilities = [%s]", strings.Join(quoted, ", "))
-	}
+	capabilityLine := formatCapabilitiesLine(capabilities, "\t  ")
 	return fmt.Sprintf(`
 %s
 
@@ -153,14 +145,7 @@ resource "agyn_runner" "test" {
 }
 
 func testAccAgynRunnerConfigWithLabels(name, environment, team string, capabilities []string) string {
-	capabilityLine := ""
-	if len(capabilities) > 0 {
-		quoted := make([]string, 0, len(capabilities))
-		for _, capability := range capabilities {
-			quoted = append(quoted, fmt.Sprintf("%q", capability))
-		}
-		capabilityLine = fmt.Sprintf("\n\t  capabilities = [%s]", strings.Join(quoted, ", "))
-	}
+	capabilityLine := formatCapabilitiesLine(capabilities, "\t  ")
 	return fmt.Sprintf(`
 %s
 
@@ -176,14 +161,7 @@ resource "agyn_runner" "test" {
 }
 
 func testAccAgynRunnerConfigWithOrganizationID(name, organizationID string, capabilities []string) string {
-	capabilityLine := ""
-	if len(capabilities) > 0 {
-		quoted := make([]string, 0, len(capabilities))
-		for _, capability := range capabilities {
-			quoted = append(quoted, fmt.Sprintf("%q", capability))
-		}
-		capabilityLine = fmt.Sprintf("\n\t  capabilities = [%s]", strings.Join(quoted, ", "))
-	}
+	capabilityLine := formatCapabilitiesLine(capabilities, "\t  ")
 	return fmt.Sprintf(`
 %s
 

--- a/internal/provider/resource_runner_test.go
+++ b/internal/provider/resource_runner_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -17,9 +18,11 @@ func TestAccAgynRunner_basic(t *testing.T) {
 		PreCheck:                 func() { testAccRunnerPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynRunnerConfig(name),
+				Config: testAccAgynRunnerConfig(name, []string{"docker"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_runner.test", "name", name),
+					resource.TestCheckResourceAttr("agyn_runner.test", "capabilities.#", "1"),
+					resource.TestCheckResourceAttr("agyn_runner.test", "capabilities.0", "docker"),
 					resource.TestCheckResourceAttrSet("agyn_runner.test", "identity_id"),
 					resource.TestCheckResourceAttrSet("agyn_runner.test", "service_token"),
 					resource.TestCheckResourceAttrSet("agyn_runner.test", "id"),
@@ -37,24 +40,26 @@ func TestAccAgynRunner_update(t *testing.T) {
 		PreCheck:                 func() { testAccRunnerPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynRunnerConfigWithLabels(name, "test", "infra"),
+				Config: testAccAgynRunnerConfigWithLabels(name, "test", "infra", []string{"docker"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_runner.test", "name", name),
 					resource.TestCheckResourceAttr("agyn_runner.test", "labels.%", "2"),
 					resource.TestCheckResourceAttr("agyn_runner.test", "labels.environment", "test"),
 					resource.TestCheckResourceAttr("agyn_runner.test", "labels.team", "infra"),
+					resource.TestCheckResourceAttr("agyn_runner.test", "capabilities.#", "1"),
 					resource.TestCheckResourceAttrSet("agyn_runner.test", "identity_id"),
 					resource.TestCheckResourceAttrSet("agyn_runner.test", "service_token"),
 					resource.TestCheckResourceAttrSet("agyn_runner.test", "id"),
 				),
 			},
 			{
-				Config: testAccAgynRunnerConfigWithLabels(updatedName, "prod", "platform"),
+				Config: testAccAgynRunnerConfigWithLabels(updatedName, "prod", "platform", []string{"docker", "gpu"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_runner.test", "name", updatedName),
 					resource.TestCheckResourceAttr("agyn_runner.test", "labels.%", "2"),
 					resource.TestCheckResourceAttr("agyn_runner.test", "labels.environment", "prod"),
 					resource.TestCheckResourceAttr("agyn_runner.test", "labels.team", "platform"),
+					resource.TestCheckResourceAttr("agyn_runner.test", "capabilities.#", "2"),
 					resource.TestCheckResourceAttrSet("agyn_runner.test", "identity_id"),
 					resource.TestCheckResourceAttrSet("agyn_runner.test", "service_token"),
 					resource.TestCheckResourceAttrSet("agyn_runner.test", "id"),
@@ -73,17 +78,18 @@ func TestAccAgynRunner_organizationIDRequiresReplace(t *testing.T) {
 		PreCheck:                 func() { testAccRunnerOrgPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynRunnerConfigWithOrganizationID(name, organizationID),
+				Config: testAccAgynRunnerConfigWithOrganizationID(name, organizationID, []string{"docker"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_runner.test", "name", name),
 					resource.TestCheckResourceAttr("agyn_runner.test", "organization_id", organizationID),
+					resource.TestCheckResourceAttr("agyn_runner.test", "capabilities.#", "1"),
 					resource.TestCheckResourceAttrSet("agyn_runner.test", "identity_id"),
 					resource.TestCheckResourceAttrSet("agyn_runner.test", "service_token"),
 					resource.TestCheckResourceAttrSet("agyn_runner.test", "id"),
 				),
 			},
 			{
-				Config: testAccAgynRunnerConfigWithOrganizationID(name, updatedOrganizationID),
+				Config: testAccAgynRunnerConfigWithOrganizationID(name, updatedOrganizationID, []string{"docker"}),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("agyn_runner.test", plancheck.ResourceActionReplace),
@@ -101,7 +107,7 @@ func TestAccAgynRunner_import(t *testing.T) {
 		PreCheck:                 func() { testAccRunnerPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynRunnerConfig(name),
+				Config: testAccAgynRunnerConfig(name, []string{"docker"}),
 			},
 			{
 				ResourceName:            "agyn_runner.test",
@@ -127,17 +133,34 @@ func testAccRunnerOrgPreCheck(t *testing.T) {
 	}
 }
 
-func testAccAgynRunnerConfig(name string) string {
+func testAccAgynRunnerConfig(name string, capabilities []string) string {
+	capabilityLine := ""
+	if len(capabilities) > 0 {
+		quoted := make([]string, 0, len(capabilities))
+		for _, capability := range capabilities {
+			quoted = append(quoted, fmt.Sprintf("%q", capability))
+		}
+		capabilityLine = fmt.Sprintf("\n\t  capabilities = [%s]", strings.Join(quoted, ", "))
+	}
 	return fmt.Sprintf(`
 %s
 
 resource "agyn_runner" "test" {
 	  name = %q
+%s
 }
-`, testAccProviderConfig(), name)
+`, testAccProviderConfig(), name, capabilityLine)
 }
 
-func testAccAgynRunnerConfigWithLabels(name, environment, team string) string {
+func testAccAgynRunnerConfigWithLabels(name, environment, team string, capabilities []string) string {
+	capabilityLine := ""
+	if len(capabilities) > 0 {
+		quoted := make([]string, 0, len(capabilities))
+		for _, capability := range capabilities {
+			quoted = append(quoted, fmt.Sprintf("%q", capability))
+		}
+		capabilityLine = fmt.Sprintf("\n\t  capabilities = [%s]", strings.Join(quoted, ", "))
+	}
 	return fmt.Sprintf(`
 %s
 
@@ -147,17 +170,27 @@ resource "agyn_runner" "test" {
 			environment = %q
 			team        = %q
 	  }
+%s
 }
-`, testAccProviderConfig(), name, environment, team)
+`, testAccProviderConfig(), name, environment, team, capabilityLine)
 }
 
-func testAccAgynRunnerConfigWithOrganizationID(name, organizationID string) string {
+func testAccAgynRunnerConfigWithOrganizationID(name, organizationID string, capabilities []string) string {
+	capabilityLine := ""
+	if len(capabilities) > 0 {
+		quoted := make([]string, 0, len(capabilities))
+		for _, capability := range capabilities {
+			quoted = append(quoted, fmt.Sprintf("%q", capability))
+		}
+		capabilityLine = fmt.Sprintf("\n\t  capabilities = [%s]", strings.Join(quoted, ", "))
+	}
 	return fmt.Sprintf(`
 %s
 
 resource "agyn_runner" "test" {
 	  name            = %q
 	  organization_id = %q
+%s
 }
-`, testAccProviderConfig(), name, organizationID)
+`, testAccProviderConfig(), name, organizationID, capabilityLine)
 }

--- a/internal/resources/agent_resource.go
+++ b/internal/resources/agent_resource.go
@@ -38,6 +38,7 @@ type agentModel struct {
 	Description    types.String           `tfsdk:"description"`
 	Configuration  types.String           `tfsdk:"configuration"`
 	IdleTimeout    types.String           `tfsdk:"idle_timeout"`
+	Capabilities   types.List             `tfsdk:"capabilities"`
 	Resources      *computeResourcesModel `tfsdk:"resources"`
 }
 
@@ -107,6 +108,11 @@ func (r *agentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Computed:            true,
 				MarkdownDescription: "Go duration string for idle timeout (for example, \"30s\", \"5m\", \"1h\").",
 			},
+			"capabilities": schema.ListAttribute{
+				Optional:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Capabilities supported by this agent.",
+			},
 			"resources": schema.SingleNestedAttribute{
 				Optional:            true,
 				MarkdownDescription: "Compute resource requests and limits.",
@@ -147,6 +153,12 @@ func (r *agentResource) Create(ctx context.Context, req resource.CreateRequest, 
 		}
 	}
 
+	capabilities, diags := stringListFromPlan(ctx, plan.Capabilities)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	input := &agentsv1.CreateAgentRequest{
 		OrganizationId: plan.OrganizationID.ValueString(),
 		Name:           plan.Name.ValueString(),
@@ -157,6 +169,7 @@ func (r *agentResource) Create(ctx context.Context, req resource.CreateRequest, 
 		InitImage:      plan.InitImage.ValueString(),
 		Description:    stringValue(plan.Description),
 		Configuration:  stringValue(plan.Configuration),
+		Capabilities:   capabilities,
 		Resources:      computeResourcesFromModel(plan.Resources),
 	}
 	if !plan.IdleTimeout.IsNull() && !plan.IdleTimeout.IsUnknown() {
@@ -175,6 +188,12 @@ func (r *agentResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
+	capabilitiesState, diags := stringListToState(ctx, agent.Capabilities, plan.Capabilities)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	updatedState := agentModel{
 		ID:             types.StringValue(agent.Meta.Id),
 		OrganizationID: types.StringValue(agent.OrganizationId),
@@ -187,6 +206,7 @@ func (r *agentResource) Create(ctx context.Context, req resource.CreateRequest, 
 		Description:    optionalString(agent.Description),
 		Configuration:  configuration,
 		IdleTimeout:    optionalString(agent.GetIdleTimeout()),
+		Capabilities:   capabilitiesState,
 		Resources:      computeResourcesToModel(agent.Resources),
 	}
 
@@ -221,6 +241,12 @@ func (r *agentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	capabilitiesState, diags := stringListToState(ctx, agent.Capabilities, state.Capabilities)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	state.Name = types.StringValue(agent.Name)
 	state.Nickname = optionalString(agent.Nickname)
 	state.Role = types.StringValue(agent.Role)
@@ -231,6 +257,7 @@ func (r *agentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	state.Description = optionalString(agent.Description)
 	state.Configuration = configuration
 	state.IdleTimeout = optionalString(agent.GetIdleTimeout())
+	state.Capabilities = capabilitiesState
 	state.Resources = computeResourcesToModel(agent.Resources)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -257,6 +284,12 @@ func (r *agentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		}
 	}
 
+	capabilities, diags := stringListFromPlan(ctx, plan.Capabilities)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	input := &agentsv1.UpdateAgentRequest{
 		Id:            plan.ID.ValueString(),
 		Name:          updateStringPointer(plan.Name, state.Name),
@@ -268,6 +301,7 @@ func (r *agentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		Description:   updateStringPointer(plan.Description, state.Description),
 		Configuration: updateStringPointer(plan.Configuration, state.Configuration),
 		IdleTimeout:   updateStringPointer(plan.IdleTimeout, state.IdleTimeout),
+		Capabilities:  capabilities,
 		Resources:     updateComputeResources(plan.Resources, state.Resources),
 	}
 
@@ -278,6 +312,12 @@ func (r *agentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	configuration, diags := normalizeJSONState(plan.Configuration, agent.Configuration)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	capabilitiesState, diags := stringListToState(ctx, agent.Capabilities, plan.Capabilities)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -295,6 +335,7 @@ func (r *agentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		Description:    optionalString(agent.Description),
 		Configuration:  configuration,
 		IdleTimeout:    optionalString(agent.GetIdleTimeout()),
+		Capabilities:   capabilitiesState,
 		Resources:      computeResourcesToModel(agent.Resources),
 	}
 

--- a/internal/resources/common_test.go
+++ b/internal/resources/common_test.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -58,5 +59,68 @@ func TestPreserveSensitiveString(t *testing.T) {
 
 	if got := preserveSensitiveString(fallback, "secret"); got.ValueString() != "secret" {
 		t.Fatalf("expected api value, got %v", got)
+	}
+}
+
+func TestStringListFromPlan(t *testing.T) {
+	ctx := context.Background()
+	if values, diags := stringListFromPlan(ctx, types.ListNull(types.StringType)); diags.HasError() || values != nil {
+		t.Fatalf("expected nil values for null list, got %v (%v)", values, diags)
+	}
+	if values, diags := stringListFromPlan(ctx, types.ListUnknown(types.StringType)); diags.HasError() || values != nil {
+		t.Fatalf("expected nil values for unknown list, got %v (%v)", values, diags)
+	}
+	list, diags := types.ListValueFrom(ctx, types.StringType, []string{"alpha", "beta"})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	values, diags := stringListFromPlan(ctx, list)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(values) != 2 || values[0] != "alpha" || values[1] != "beta" {
+		t.Fatalf("unexpected values: %#v", values)
+	}
+}
+
+func TestStringListToState(t *testing.T) {
+	ctx := context.Background()
+	list, diags := stringListToState(ctx, nil, types.ListNull(types.StringType))
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !list.IsNull() {
+		t.Fatalf("expected null list state, got %v", list)
+	}
+
+	prior, diags := types.ListValueFrom(ctx, types.StringType, []string{"prior"})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	list, diags = stringListToState(ctx, nil, prior)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if list.IsNull() {
+		t.Fatalf("expected empty list state, got null")
+	}
+	values := []string{}
+	if diags := list.ElementsAs(ctx, &values, false); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(values) != 0 {
+		t.Fatalf("expected empty list, got %#v", values)
+	}
+
+	list, diags = stringListToState(ctx, []string{"one", "two"}, types.ListNull(types.StringType))
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	values = []string{}
+	if diags := list.ElementsAs(ctx, &values, false); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(values) != 2 || values[0] != "one" || values[1] != "two" {
+		t.Fatalf("unexpected list values: %#v", values)
 	}
 }

--- a/internal/resources/list_helpers.go
+++ b/internal/resources/list_helpers.go
@@ -1,0 +1,27 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func stringListFromPlan(ctx context.Context, list types.List) ([]string, diag.Diagnostics) {
+	if list.IsNull() || list.IsUnknown() {
+		return nil, nil
+	}
+	values := []string{}
+	diags := list.ElementsAs(ctx, &values, false)
+	return values, diags
+}
+
+func stringListToState(ctx context.Context, values []string, prior types.List) (types.List, diag.Diagnostics) {
+	if len(values) == 0 {
+		if prior.IsNull() || prior.IsUnknown() {
+			return types.ListNull(types.StringType), nil
+		}
+		values = []string{}
+	}
+	return types.ListValueFrom(ctx, types.StringType, values)
+}

--- a/internal/resources/runner_resource.go
+++ b/internal/resources/runner_resource.go
@@ -29,6 +29,7 @@ type runnerModel struct {
 	Name           types.String `tfsdk:"name"`
 	OrganizationID types.String `tfsdk:"organization_id"`
 	Labels         types.Map    `tfsdk:"labels"`
+	Capabilities   types.List   `tfsdk:"capabilities"`
 	IdentityID     types.String `tfsdk:"identity_id"`
 	ServiceToken   types.String `tfsdk:"service_token"`
 }
@@ -61,6 +62,11 @@ func (r *runnerResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Optional:            true,
 				ElementType:         types.StringType,
 				MarkdownDescription: "Runner labels.",
+			},
+			"capabilities": schema.ListAttribute{
+				Optional:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Capabilities supported by this runner.",
 			},
 			"identity_id": schema.StringAttribute{
 				Computed:            true,
@@ -107,9 +113,16 @@ func (r *runnerResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	capabilities, diags := stringListFromPlan(ctx, plan.Capabilities)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	input := &runnersv1.RegisterRunnerRequest{
-		Name:   plan.Name.ValueString(),
-		Labels: labels,
+		Name:         plan.Name.ValueString(),
+		Labels:       labels,
+		Capabilities: capabilities,
 	}
 	if !plan.OrganizationID.IsNull() && !plan.OrganizationID.IsUnknown() {
 		input.OrganizationId = proto.String(plan.OrganizationID.ValueString())
@@ -121,7 +134,7 @@ func (r *runnerResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	updatedState, diags := runnerToState(result.Runner, plan.Labels, optionalString(result.ServiceToken))
+	updatedState, diags := runnerToState(ctx, result.Runner, plan.Labels, plan.Capabilities, optionalString(result.ServiceToken))
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -152,7 +165,7 @@ func (r *runnerResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	updatedState, diags := runnerToState(runner, state.Labels, preserveSensitiveString(state.ServiceToken, ""))
+	updatedState, diags := runnerToState(ctx, runner, state.Labels, state.Capabilities, preserveSensitiveString(state.ServiceToken, ""))
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -181,10 +194,17 @@ func (r *runnerResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
+	capabilities, diags := stringListFromPlan(ctx, plan.Capabilities)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	input := &runnersv1.UpdateRunnerRequest{
-		Id:     plan.ID.ValueString(),
-		Name:   updateStringPointer(plan.Name, state.Name),
-		Labels: labels,
+		Id:           plan.ID.ValueString(),
+		Name:         updateStringPointer(plan.Name, state.Name),
+		Labels:       labels,
+		Capabilities: capabilities,
 	}
 
 	runner, err := r.client.UpdateRunner(ctx, input)
@@ -193,7 +213,7 @@ func (r *runnerResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	updatedState, diags := runnerToState(runner, plan.Labels, preserveSensitiveString(state.ServiceToken, ""))
+	updatedState, diags := runnerToState(ctx, runner, plan.Labels, plan.Capabilities, preserveSensitiveString(state.ServiceToken, ""))
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -227,16 +247,27 @@ func (r *runnerResource) ImportState(ctx context.Context, req resource.ImportSta
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func runnerToState(runner *runnersv1.Runner, priorLabels types.Map, serviceToken types.String) (runnerModel, diag.Diagnostics) {
+func runnerToState(
+	ctx context.Context,
+	runner *runnersv1.Runner,
+	priorLabels types.Map,
+	priorCapabilities types.List,
+	serviceToken types.String,
+) (runnerModel, diag.Diagnostics) {
 	labels, diags := runnerLabelsToState(runner.Labels, priorLabels)
+	if diags.HasError() {
+		return runnerModel{}, diags
+	}
+	capabilities, capDiags := stringListToState(ctx, runner.Capabilities, priorCapabilities)
 	return runnerModel{
 		ID:             types.StringValue(runner.Meta.Id),
 		Name:           types.StringValue(runner.Name),
 		OrganizationID: optionalString(runner.GetOrganizationId()),
 		Labels:         labels,
+		Capabilities:   capabilities,
 		IdentityID:     optionalString(runner.IdentityId),
 		ServiceToken:   serviceToken,
-	}, diags
+	}, append(diags, capDiags...)
 }
 
 func runnerLabelsToState(labels map[string]string, prior types.Map) (types.Map, diag.Diagnostics) {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	version = "dev"
+	version = "0.6.9"
 	commit  = ""
 )
 


### PR DESCRIPTION
## Summary
- update buf.lock and regenerate API bindings to pick up capabilities
- add capabilities list support for agyn_agent and agyn_runner resources
- extend docs and tests for capabilities list handling
- bump provider version to 0.6.9

## Testing
- buf generate
- go test ./...
- go vet ./...
- go build ./...

Relates to #133