### PR TITLE
feat: add username to agyn_user resource

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -20,6 +20,7 @@ inputs:
       - agynio/api/apps/v1/apps.proto
       - agynio/api/llm/v1/llm.proto
       - agynio/api/organizations/v1/organizations.proto
+      - agynio/api/runner/v1
       - agynio/api/runners/v1/runners.proto
       - agynio/api/gateway/v1/agents.proto
       - agynio/api/gateway/v1/apps.proto

--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: bbd8e6ab60974e9eb324ba9c4eeda240
-    digest: shake256:803c10c71ad07ed7b1f2cc531c499f4fdbf7598937f51ca7ed353ae67d8950f8f789ac23ac5bd3b2c2e1c623b1a68ff2835925bf3bd4c36356912f54804aebb7
+    commit: 74e093945d7343239e9933d5de061836
+    digest: shake256:c1420b93ac8584914a9c69b0b94484a142f25af06c7f48a6c3a0156499b84ac29e390f517c409387394c640bcbc3f6dc6fa2e8fabcfacd60a6ce70a707c20412
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -23,8 +23,8 @@ Manages an Agyn user.
 
 - `cluster_role` (String) Cluster role for the user (admin or none).
 - `name` (String) Display name for the user.
-- `nickname` (String) Nickname for the user.
 - `photo_url` (String) Photo URL for the user.
+- `username` (String) Cluster-wide username for the user.
 
 ### Read-Only
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -23,6 +23,7 @@ Manages an Agyn user.
 
 - `cluster_role` (String) Cluster role for the user (admin or none).
 - `name` (String) Display name for the user.
+- `nickname` (String, Deprecated) Deprecated: use username. When set without username, the value is used as the username.
 - `photo_url` (String) Photo URL for the user.
 - `username` (String) Cluster-wide username for the user.
 

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -13,18 +13,18 @@ func TestAccAgynUser_basic(t *testing.T) {
 	oidcSubject := fmt.Sprintf("%s@example.com", acctest.RandomWithPrefix("tf-acc-user"))
 	name := "Terraform acceptance user"
 	photoURL := "https://example.com/user.png"
-	nickname := acctest.RandomWithPrefix("tf-acc-nickname")
+	username := acctest.RandomWithPrefix("tf-acc-username")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck:                 func() { testAccUserPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, nickname, "none"),
+				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, username, "none"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_user.test", "oidc_subject", oidcSubject),
 					resource.TestCheckResourceAttr("agyn_user.test", "name", name),
 					resource.TestCheckResourceAttr("agyn_user.test", "photo_url", photoURL),
-					resource.TestCheckResourceAttr("agyn_user.test", "nickname", nickname),
+					resource.TestCheckResourceAttr("agyn_user.test", "username", username),
 					resource.TestCheckResourceAttr("agyn_user.test", "cluster_role", "none"),
 					resource.TestCheckResourceAttrSet("agyn_user.test", "identity_id"),
 				),
@@ -37,20 +37,20 @@ func TestAccAgynUser_update(t *testing.T) {
 	oidcSubject := fmt.Sprintf("%s@example.com", acctest.RandomWithPrefix("tf-acc-user"))
 	name := "Terraform acceptance user"
 	photoURL := "https://example.com/user.png"
-	nickname := acctest.RandomWithPrefix("tf-acc-nickname")
+	username := acctest.RandomWithPrefix("tf-acc-username")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck:                 func() { testAccUserPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, nickname, "none"),
+				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, username, "none"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_user.test", "cluster_role", "none"),
 					resource.TestCheckResourceAttrSet("agyn_user.test", "identity_id"),
 				),
 			},
 			{
-				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, nickname, "admin"),
+				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, username, "admin"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_user.test", "cluster_role", "admin"),
 					resource.TestCheckResourceAttrSet("agyn_user.test", "identity_id"),
@@ -64,13 +64,13 @@ func TestAccAgynUser_import(t *testing.T) {
 	oidcSubject := fmt.Sprintf("%s@example.com", acctest.RandomWithPrefix("tf-acc-user"))
 	name := "Terraform acceptance user"
 	photoURL := "https://example.com/user.png"
-	nickname := acctest.RandomWithPrefix("tf-acc-nickname")
+	username := acctest.RandomWithPrefix("tf-acc-username")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck:                 func() { testAccUserPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, nickname, "admin"),
+				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, username, "admin"),
 			},
 			{
 				ResourceName:      "agyn_user.test",
@@ -88,7 +88,7 @@ func testAccUserPreCheck(t *testing.T) {
 	}
 }
 
-func testAccAgynUserConfig(oidcSubject, name, photoURL, nickname, clusterRole string) string {
+func testAccAgynUserConfig(oidcSubject, name, photoURL, username, clusterRole string) string {
 	nameLine := ""
 	if name != "" {
 		nameLine = fmt.Sprintf("\n\t  name         = %q", name)
@@ -97,9 +97,9 @@ func testAccAgynUserConfig(oidcSubject, name, photoURL, nickname, clusterRole st
 	if photoURL != "" {
 		photoLine = fmt.Sprintf("\n\t  photo_url    = %q", photoURL)
 	}
-	nicknameLine := ""
-	if nickname != "" {
-		nicknameLine = fmt.Sprintf("\n\t  nickname     = %q", nickname)
+	usernameLine := ""
+	if username != "" {
+		usernameLine = fmt.Sprintf("\n\t  username     = %q", username)
 	}
 	clusterLine := ""
 	if clusterRole != "" {
@@ -112,5 +112,5 @@ func testAccAgynUserConfig(oidcSubject, name, photoURL, nickname, clusterRole st
 resource "agyn_user" "test" {
 	  oidc_subject = %q%s%s%s%s
 }
-`, testAccProviderConfig(), oidcSubject, nameLine, photoLine, nicknameLine, clusterLine)
+`, testAccProviderConfig(), oidcSubject, nameLine, photoLine, usernameLine, clusterLine)
 }

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -13,18 +13,19 @@ func TestAccAgynUser_basic(t *testing.T) {
 	oidcSubject := fmt.Sprintf("%s@example.com", acctest.RandomWithPrefix("tf-acc-user"))
 	name := "Terraform acceptance user"
 	photoURL := "https://example.com/user.png"
-	username := acctest.RandomWithPrefix("tf-acc-username")
+	nickname := acctest.RandomWithPrefix("tf-acc-nickname")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck:                 func() { testAccUserPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, username, "none"),
+				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, "", nickname, "none"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_user.test", "oidc_subject", oidcSubject),
 					resource.TestCheckResourceAttr("agyn_user.test", "name", name),
 					resource.TestCheckResourceAttr("agyn_user.test", "photo_url", photoURL),
-					resource.TestCheckResourceAttr("agyn_user.test", "username", username),
+					resource.TestCheckResourceAttr("agyn_user.test", "nickname", nickname),
+					resource.TestCheckResourceAttr("agyn_user.test", "username", nickname),
 					resource.TestCheckResourceAttr("agyn_user.test", "cluster_role", "none"),
 					resource.TestCheckResourceAttrSet("agyn_user.test", "identity_id"),
 				),
@@ -43,14 +44,15 @@ func TestAccAgynUser_update(t *testing.T) {
 		PreCheck:                 func() { testAccUserPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, username, "none"),
+				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, username, "", "none"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_user.test", "cluster_role", "none"),
+					resource.TestCheckResourceAttr("agyn_user.test", "nickname", username),
 					resource.TestCheckResourceAttrSet("agyn_user.test", "identity_id"),
 				),
 			},
 			{
-				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, username, "admin"),
+				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, username, "", "admin"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("agyn_user.test", "cluster_role", "admin"),
 					resource.TestCheckResourceAttrSet("agyn_user.test", "identity_id"),
@@ -70,7 +72,7 @@ func TestAccAgynUser_import(t *testing.T) {
 		PreCheck:                 func() { testAccUserPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, username, "admin"),
+				Config: testAccAgynUserConfig(oidcSubject, name, photoURL, username, "", "admin"),
 			},
 			{
 				ResourceName:      "agyn_user.test",
@@ -88,7 +90,7 @@ func testAccUserPreCheck(t *testing.T) {
 	}
 }
 
-func testAccAgynUserConfig(oidcSubject, name, photoURL, username, clusterRole string) string {
+func testAccAgynUserConfig(oidcSubject, name, photoURL, username, nickname, clusterRole string) string {
 	nameLine := ""
 	if name != "" {
 		nameLine = fmt.Sprintf("\n\t  name         = %q", name)
@@ -101,6 +103,10 @@ func testAccAgynUserConfig(oidcSubject, name, photoURL, username, clusterRole st
 	if username != "" {
 		usernameLine = fmt.Sprintf("\n\t  username     = %q", username)
 	}
+	nicknameLine := ""
+	if nickname != "" {
+		nicknameLine = fmt.Sprintf("\n\t  nickname     = %q", nickname)
+	}
 	clusterLine := ""
 	if clusterRole != "" {
 		clusterLine = fmt.Sprintf("\n\t  cluster_role = %q", clusterRole)
@@ -110,7 +116,7 @@ func testAccAgynUserConfig(oidcSubject, name, photoURL, username, clusterRole st
 %s
 
 resource "agyn_user" "test" {
-	  oidc_subject = %q%s%s%s%s
+	  oidc_subject = %q%s%s%s%s%s
 }
-`, testAccProviderConfig(), oidcSubject, nameLine, photoLine, usernameLine, clusterLine)
+`, testAccProviderConfig(), oidcSubject, nameLine, photoLine, usernameLine, nicknameLine, clusterLine)
 }

--- a/internal/resources/user_resource.go
+++ b/internal/resources/user_resource.go
@@ -29,7 +29,7 @@ type userModel struct {
 	OIDCSubject types.String `tfsdk:"oidc_subject"`
 	Name        types.String `tfsdk:"name"`
 	PhotoURL    types.String `tfsdk:"photo_url"`
-	Nickname    types.String `tfsdk:"nickname"`
+	Username    types.String `tfsdk:"username"`
 	ClusterRole types.String `tfsdk:"cluster_role"`
 }
 
@@ -61,9 +61,10 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Optional:            true,
 				MarkdownDescription: "Photo URL for the user.",
 			},
-			"nickname": schema.StringAttribute{
+			"username": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Nickname for the user.",
+				Computed:            true,
+				MarkdownDescription: "Cluster-wide username for the user.",
 			},
 			"cluster_role": schema.StringAttribute{
 				Optional:            true,
@@ -102,7 +103,7 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 	input := &usersv1.CreateUserRequest{OidcSubject: plan.OIDCSubject.ValueString()}
 	input.Name = planStringPointer(plan.Name)
 	input.PhotoUrl = planStringPointer(plan.PhotoURL)
-	input.Nickname = planStringPointer(plan.Nickname)
+	input.Username = planStringPointer(plan.Username)
 
 	user, err := r.client.CreateUser(ctx, input)
 	if err != nil {
@@ -185,8 +186,8 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		input.PhotoUrl = value
 		needsUpdate = true
 	}
-	if value := updateStringPointer(plan.Nickname, state.Nickname); value != nil {
-		input.Nickname = value
+	if value := updateStringPointer(plan.Username, state.Username); value != nil {
+		input.Username = value
 		needsUpdate = true
 	}
 	if value := updateClusterRolePointer(plan.ClusterRole, state.ClusterRole); value != nil {
@@ -250,7 +251,7 @@ func (r *userResource) readUser(ctx context.Context, identityID string) (userMod
 		OIDCSubject: types.StringValue(user.GetOidcSubject()),
 		Name:        optionalString(user.GetName()),
 		PhotoURL:    optionalString(user.GetPhotoUrl()),
-		Nickname:    optionalString(user.GetNickname()),
+		Username:    optionalString(user.GetUsername()),
 		ClusterRole: types.StringValue(fromProtoClusterRole(clusterRole)),
 	}, nil
 }

--- a/internal/resources/user_resource.go
+++ b/internal/resources/user_resource.go
@@ -29,6 +29,7 @@ type userModel struct {
 	OIDCSubject types.String `tfsdk:"oidc_subject"`
 	Name        types.String `tfsdk:"name"`
 	PhotoURL    types.String `tfsdk:"photo_url"`
+	Nickname    types.String `tfsdk:"nickname"`
 	Username    types.String `tfsdk:"username"`
 	ClusterRole types.String `tfsdk:"cluster_role"`
 }
@@ -60,6 +61,12 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"photo_url": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "Photo URL for the user.",
+			},
+			"nickname": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Deprecated: use username. When set without username, the value is used as the username.",
+				DeprecationMessage:  "Deprecated: use username instead. When set without username, the value is used as the username.",
 			},
 			"username": schema.StringAttribute{
 				Optional:            true,
@@ -104,6 +111,9 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 	input.Name = planStringPointer(plan.Name)
 	input.PhotoUrl = planStringPointer(plan.PhotoURL)
 	input.Username = planStringPointer(plan.Username)
+	if plan.Username.IsUnknown() {
+		input.Username = planStringPointer(plan.Nickname)
+	}
 
 	user, err := r.client.CreateUser(ctx, input)
 	if err != nil {
@@ -186,7 +196,12 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		input.PhotoUrl = value
 		needsUpdate = true
 	}
-	if value := updateStringPointer(plan.Username, state.Username); value != nil {
+	if plan.Username.IsUnknown() {
+		if value := updateStringPointer(plan.Nickname, state.Username); value != nil {
+			input.Username = value
+			needsUpdate = true
+		}
+	} else if value := updateStringPointer(plan.Username, state.Username); value != nil {
 		input.Username = value
 		needsUpdate = true
 	}
@@ -246,12 +261,19 @@ func (r *userResource) readUser(ctx context.Context, identityID string) (userMod
 		return userModel{}, err
 	}
 
+	username := optionalString(user.GetUsername())
+	nickname := username
+	if username.IsNull() {
+		nickname = optionalString(user.GetNickname())
+	}
+
 	return userModel{
 		IdentityID:  types.StringValue(value),
 		OIDCSubject: types.StringValue(user.GetOidcSubject()),
 		Name:        optionalString(user.GetName()),
 		PhotoURL:    optionalString(user.GetPhotoUrl()),
-		Username:    optionalString(user.GetUsername()),
+		Nickname:    nickname,
+		Username:    username,
 		ClusterRole: types.StringValue(fromProtoClusterRole(clusterRole)),
 	}, nil
 }


### PR DESCRIPTION
## Summary
- add username optional+computed to agyn_user and remove nickname mapping
- map create/update/read to username and refresh acceptance config
- update user docs and buf inputs for runner proto generation

## Testing
- go vet ./...
- go test ./...

Refs #140
