### PR TITLE
Send the environment's availability on update

### DIFF
--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -13,19 +13,18 @@ Manages an Agyn agent.
 ## Example Usage
 
 ```terraform
-resource "agyn_organization" "example" {
-  name = "example-org"
-}
-
 resource "agyn_agent" "example" {
   organization_id = agyn_organization.example.id
   name            = "example-agent"
   nickname        = "example-agent"
   role            = "assistant"
-  model           = "gpt-4o"
-  image           = "ghcr.io/agynio/agent-runtime:v1.0.0"
   description     = "Example agent managed by Terraform."
-  availability    = "internal"
+
+  # The environment supplies the image and compute the agent runs with.
+  environment_id = agyn_environment.build.id
+  model          = agyn_model.example.id
+  image          = "ghcr.io/agynio/agent-runtime:v1.0.0"
+  availability   = "internal"
 }
 ```
 

--- a/docs/resources/env.md
+++ b/docs/resources/env.md
@@ -13,24 +13,18 @@ Manages an Agyn environment variable.
 ## Example Usage
 
 ```terraform
-resource "agyn_organization" "example" {
-  name = "example-org"
-}
-
-resource "agyn_agent" "example" {
-  organization_id = agyn_organization.example.id
-  name            = "example-agent"
-  role            = "assistant"
-  model           = "gpt-4o"
-  image           = "ghcr.io/agynio/agent-runtime:v1.0.0"
-  description     = "Example agent managed by Terraform."
-}
-
 resource "agyn_env" "example" {
   name        = "LOG_LEVEL"
   description = "Example environment variable."
   agent_id    = agyn_agent.example.id
   value       = "info"
+}
+
+# A secret is delivered by reference: the value never enters the state file.
+resource "agyn_env" "token" {
+  name      = "API_TOKEN"
+  agent_id  = agyn_agent.example.id
+  secret_id = agyn_secret.local.id
 }
 ```
 

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -27,6 +27,10 @@ resource "agyn_environment" "build" {
   # sandbox, rejected when creating an agent.
   agent_runtime_image_id  = agyn_image.runtime_codex.id
   agent_runtime_image_tag = "0.146.0"
+
+  # Who may run workloads here. Running in an environment reaches its secrets,
+  # egress credentials and volume contents.
+  availability = "internal"
 }
 ```
 

--- a/docs/resources/init_script.md
+++ b/docs/resources/init_script.md
@@ -13,19 +13,6 @@ Manages an Agyn init script.
 ## Example Usage
 
 ```terraform
-resource "agyn_organization" "example" {
-  name = "example-org"
-}
-
-resource "agyn_agent" "example" {
-  organization_id = agyn_organization.example.id
-  name            = "example-agent"
-  role            = "assistant"
-  model           = "gpt-4o"
-  image           = "ghcr.io/agynio/agent-runtime:v1.0.0"
-  description     = "Example agent managed by Terraform."
-}
-
 resource "agyn_init_script" "example" {
   agent_id    = agyn_agent.example.id
   description = "Initialize agent workspace."

--- a/docs/resources/mcp.md
+++ b/docs/resources/mcp.md
@@ -13,25 +13,17 @@ Manages an Agyn MCP.
 ## Example Usage
 
 ```terraform
-resource "agyn_organization" "example" {
-  name = "example-org"
-}
+# An MCP server runs as a sidecar to every workload in its environment.
+resource "agyn_mcp" "search" {
+  environment_id = agyn_environment.build.id
+  name           = "search"
+  image          = "ghcr.io/agynio/mcp-search:v1.0.0"
+  command        = "mcp-search --port 8080"
+  description    = "Example MCP service."
 
-resource "agyn_agent" "example" {
-  organization_id = agyn_organization.example.id
-  name            = "example-agent"
-  role            = "assistant"
-  model           = "gpt-4o"
-  image           = "ghcr.io/agynio/agent-runtime:v1.0.0"
-  description     = "Example agent managed by Terraform."
-}
-
-resource "agyn_mcp" "example" {
-  agent_id    = agyn_agent.example.id
-  name        = "example-mcp"
-  image       = "ghcr.io/agynio/mcp-server:v1.0.0"
-  command     = "mcp-server --port 8080"
-  description = "Example MCP service."
+  # Environment volumes to mount into the sidecar, at the paths the main
+  # container uses.
+  shared_volumes = ["workspace"]
 }
 ```
 

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -13,16 +13,31 @@ Manages a volume on an environment or an MCP server. A volume is a definition, n
 ## Example Usage
 
 ```terraform
-resource "agyn_organization" "example" {
-  name = "example-org"
+# A volume is a definition, not a disk: one disk is provisioned per agent
+# instance and per sandbox that runs the environment mounting it.
+resource "agyn_volume" "workspace" {
+  environment_id = agyn_environment.build.id
+  name           = "workspace"
+  mount_path     = "/workspace"
+  size           = "10Gi"
+  ttl            = "168h"
 }
 
-resource "agyn_volume" "example" {
-  organization_id = agyn_organization.example.id
-  persistent      = true
-  mount_path      = "/data"
-  size            = "10Gi"
-  description     = "Example persistent volume."
+# No size makes the volume ephemeral scratch: a fresh empty mount per workload.
+resource "agyn_volume" "cache" {
+  environment_id = agyn_environment.build.id
+  name           = "cache"
+  mount_path     = "/home/agent/.cache"
+}
+
+# An MCP sidecar mounts volumes of its own. An MCP's shared_volumes names the
+# environment's volumes instead, by the name declared here.
+resource "agyn_volume" "index" {
+  mcp_id        = agyn_mcp.search.id
+  name          = "index"
+  mount_path    = "/var/lib/index"
+  size          = "5Gi"
+  storage_class = "fast"
 }
 ```
 

--- a/examples/resources/agyn_agent/resource.tf
+++ b/examples/resources/agyn_agent/resource.tf
@@ -1,14 +1,13 @@
-resource "agyn_organization" "example" {
-  name = "example-org"
-}
-
 resource "agyn_agent" "example" {
   organization_id = agyn_organization.example.id
   name            = "example-agent"
   nickname        = "example-agent"
   role            = "assistant"
-  model           = "gpt-4o"
-  image           = "ghcr.io/agynio/agent-runtime:v1.0.0"
   description     = "Example agent managed by Terraform."
-  availability    = "internal"
+
+  # The environment supplies the image and compute the agent runs with.
+  environment_id = agyn_environment.build.id
+  model          = agyn_model.example.id
+  image          = "ghcr.io/agynio/agent-runtime:v1.0.0"
+  availability   = "internal"
 }

--- a/examples/resources/agyn_env/resource.tf
+++ b/examples/resources/agyn_env/resource.tf
@@ -1,19 +1,13 @@
-resource "agyn_organization" "example" {
-  name = "example-org"
-}
-
-resource "agyn_agent" "example" {
-  organization_id = agyn_organization.example.id
-  name            = "example-agent"
-  role            = "assistant"
-  model           = "gpt-4o"
-  image           = "ghcr.io/agynio/agent-runtime:v1.0.0"
-  description     = "Example agent managed by Terraform."
-}
-
 resource "agyn_env" "example" {
   name        = "LOG_LEVEL"
   description = "Example environment variable."
   agent_id    = agyn_agent.example.id
   value       = "info"
+}
+
+# A secret is delivered by reference: the value never enters the state file.
+resource "agyn_env" "token" {
+  name      = "API_TOKEN"
+  agent_id  = agyn_agent.example.id
+  secret_id = agyn_secret.local.id
 }

--- a/examples/resources/agyn_environment/resource.tf
+++ b/examples/resources/agyn_environment/resource.tf
@@ -12,4 +12,8 @@ resource "agyn_environment" "build" {
   # sandbox, rejected when creating an agent.
   agent_runtime_image_id  = agyn_image.runtime_codex.id
   agent_runtime_image_tag = "0.146.0"
+
+  # Who may run workloads here. Running in an environment reaches its secrets,
+  # egress credentials and volume contents.
+  availability = "internal"
 }

--- a/examples/resources/agyn_init_script/resource.tf
+++ b/examples/resources/agyn_init_script/resource.tf
@@ -1,16 +1,3 @@
-resource "agyn_organization" "example" {
-  name = "example-org"
-}
-
-resource "agyn_agent" "example" {
-  organization_id = agyn_organization.example.id
-  name            = "example-agent"
-  role            = "assistant"
-  model           = "gpt-4o"
-  image           = "ghcr.io/agynio/agent-runtime:v1.0.0"
-  description     = "Example agent managed by Terraform."
-}
-
 resource "agyn_init_script" "example" {
   agent_id    = agyn_agent.example.id
   description = "Initialize agent workspace."

--- a/examples/resources/agyn_mcp/resource.tf
+++ b/examples/resources/agyn_mcp/resource.tf
@@ -1,20 +1,12 @@
-resource "agyn_organization" "example" {
-  name = "example-org"
-}
+# An MCP server runs as a sidecar to every workload in its environment.
+resource "agyn_mcp" "search" {
+  environment_id = agyn_environment.build.id
+  name           = "search"
+  image          = "ghcr.io/agynio/mcp-search:v1.0.0"
+  command        = "mcp-search --port 8080"
+  description    = "Example MCP service."
 
-resource "agyn_agent" "example" {
-  organization_id = agyn_organization.example.id
-  name            = "example-agent"
-  role            = "assistant"
-  model           = "gpt-4o"
-  image           = "ghcr.io/agynio/agent-runtime:v1.0.0"
-  description     = "Example agent managed by Terraform."
-}
-
-resource "agyn_mcp" "example" {
-  agent_id    = agyn_agent.example.id
-  name        = "example-mcp"
-  image       = "ghcr.io/agynio/mcp-server:v1.0.0"
-  command     = "mcp-server --port 8080"
-  description = "Example MCP service."
+  # Environment volumes to mount into the sidecar, at the paths the main
+  # container uses.
+  shared_volumes = ["workspace"]
 }

--- a/examples/resources/agyn_volume/resource.tf
+++ b/examples/resources/agyn_volume/resource.tf
@@ -1,11 +1,26 @@
-resource "agyn_organization" "example" {
-  name = "example-org"
+# A volume is a definition, not a disk: one disk is provisioned per agent
+# instance and per sandbox that runs the environment mounting it.
+resource "agyn_volume" "workspace" {
+  environment_id = agyn_environment.build.id
+  name           = "workspace"
+  mount_path     = "/workspace"
+  size           = "10Gi"
+  ttl            = "168h"
 }
 
-resource "agyn_volume" "example" {
-  organization_id = agyn_organization.example.id
-  persistent      = true
-  mount_path      = "/data"
-  size            = "10Gi"
-  description     = "Example persistent volume."
+# No size makes the volume ephemeral scratch: a fresh empty mount per workload.
+resource "agyn_volume" "cache" {
+  environment_id = agyn_environment.build.id
+  name           = "cache"
+  mount_path     = "/home/agent/.cache"
+}
+
+# An MCP sidecar mounts volumes of its own. An MCP's shared_volumes names the
+# environment's volumes instead, by the name declared here.
+resource "agyn_volume" "index" {
+  mcp_id        = agyn_mcp.search.id
+  name          = "index"
+  mount_path    = "/var/lib/index"
+  size          = "5Gi"
+  storage_class = "fast"
 }

--- a/internal/resources/environment_resource.go
+++ b/internal/resources/environment_resource.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	agentsv1 "github.com/agynio/terraform-provider-agyn/gen/agynio/api/agents/v1"
@@ -34,6 +36,11 @@ type environmentModel struct {
 	AgentRuntimeImageTag types.String `tfsdk:"agent_runtime_image_tag"`
 	Availability         types.String `tfsdk:"availability"`
 }
+
+const (
+	environmentAvailabilityInternal = "internal"
+	environmentAvailabilityPrivate  = "private"
+)
 
 func NewEnvironmentResource() resource.Resource { return &environmentResource{} }
 
@@ -94,6 +101,9 @@ func (r *environmentResource) Schema(_ context.Context, _ resource.SchemaRequest
 			"availability": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "internal or private. Controls who may run workloads in the environment; running in one reaches its secrets, egress credentials and volume contents.",
+				Validators: []validator.String{
+					stringvalidator.OneOf(environmentAvailabilityInternal, environmentAvailabilityPrivate),
+				},
 			},
 		},
 	}
@@ -188,6 +198,7 @@ func (r *environmentResource) Update(ctx context.Context, req resource.UpdateReq
 		WorkspaceImageTag:    updateStringPointer(plan.WorkspaceImageTag, state.WorkspaceImageTag),
 		AgentRuntimeImageId:  updateStringPointer(plan.AgentRuntimeImageID, state.AgentRuntimeImageID),
 		AgentRuntimeImageTag: updateStringPointer(plan.AgentRuntimeImageTag, state.AgentRuntimeImageTag),
+		Availability:         environmentAvailabilityUpdate(plan.Availability),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to update environment", err.Error())
@@ -238,7 +249,7 @@ func environmentStateFrom(environment *agentsv1.Environment) environmentModel {
 }
 
 func environmentAvailabilityFromString(value string) agentsv1.EnvironmentAvailability {
-	if strings.EqualFold(strings.TrimSpace(value), "private") {
+	if strings.EqualFold(strings.TrimSpace(value), environmentAvailabilityPrivate) {
 		return agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_PRIVATE
 	}
 	return agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_INTERNAL
@@ -246,7 +257,17 @@ func environmentAvailabilityFromString(value string) agentsv1.EnvironmentAvailab
 
 func environmentAvailabilityToString(value agentsv1.EnvironmentAvailability) string {
 	if value == agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_PRIVATE {
-		return "private"
+		return environmentAvailabilityPrivate
 	}
-	return "internal"
+	return environmentAvailabilityInternal
+}
+
+// The attribute is required, so an unknown plan value is the only case with
+// nothing to send: leaving it out would silently keep the prior availability.
+func environmentAvailabilityUpdate(plan types.String) *agentsv1.EnvironmentAvailability {
+	if plan.IsNull() || plan.IsUnknown() {
+		return nil
+	}
+	availability := environmentAvailabilityFromString(plan.ValueString())
+	return &availability
 }

--- a/internal/resources/environment_resource_test.go
+++ b/internal/resources/environment_resource_test.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"testing"
+
+	agentsv1 "github.com/agynio/terraform-provider-agyn/gen/agynio/api/agents/v1"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestEnvironmentAvailabilityFromString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected agentsv1.EnvironmentAvailability
+	}{
+		{
+			name:     "internal",
+			input:    "internal",
+			expected: agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_INTERNAL,
+		},
+		{
+			name:     "private",
+			input:    "private",
+			expected: agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_PRIVATE,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := environmentAvailabilityFromString(tt.input); got != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestEnvironmentAvailabilityToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    agentsv1.EnvironmentAvailability
+		expected string
+	}{
+		{
+			name:     "internal",
+			input:    agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_INTERNAL,
+			expected: "internal",
+		},
+		{
+			name:     "private",
+			input:    agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_PRIVATE,
+			expected: "private",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := environmentAvailabilityToString(tt.input); got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+// An update that omits availability leaves the API holding the prior value,
+// which then contradicts the plan Terraform just applied.
+func TestEnvironmentAvailabilityUpdate(t *testing.T) {
+	if got := environmentAvailabilityUpdate(types.StringValue("private")); got == nil ||
+		*got != agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_PRIVATE {
+		t.Fatalf("expected private to be sent, got %v", got)
+	}
+	if got := environmentAvailabilityUpdate(types.StringUnknown()); got != nil {
+		t.Fatalf("expected an unknown value to send nothing, got %v", *got)
+	}
+}

--- a/internal/resources/volume_resource.go
+++ b/internal/resources/volume_resource.go
@@ -143,7 +143,7 @@ func (r *volumeResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, volumeStateFrom(volume, plan))...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, volumeStateFrom(volume))...)
 }
 
 func (r *volumeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -168,7 +168,7 @@ func (r *volumeResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, volumeStateFrom(volume, state))...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, volumeStateFrom(volume))...)
 }
 
 func (r *volumeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -204,7 +204,7 @@ func (r *volumeResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, volumeStateFrom(volume, state))...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, volumeStateFrom(volume))...)
 }
 
 func (r *volumeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -232,17 +232,23 @@ func (r *volumeResource) ImportState(ctx context.Context, req resource.ImportSta
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-// volumeStateFrom keeps the target from the prior model: it is immutable and the
-// API returns it in a oneof the state shape splits into two attributes.
-func volumeStateFrom(volume *agentsv1.Volume, prior volumeModel) *volumeModel {
-	return &volumeModel{
-		ID:            types.StringValue(volume.Meta.Id),
-		EnvironmentID: prior.EnvironmentID,
-		McpID:         prior.McpID,
-		Name:          types.StringValue(volume.Name),
-		MountPath:     types.StringValue(volume.MountPath),
-		Size:          optionalString(volume.Size),
-		StorageClass:  optionalString(volume.GetStorageClass()),
-		TTL:           optionalString(volume.GetTtl()),
+// The API returns the target in a oneof the state shape splits into two
+// attributes. Reading it back rather than carrying the prior value is what lets
+// an import land a volume whose target the state does not know yet.
+func volumeStateFrom(volume *agentsv1.Volume) *volumeModel {
+	state := &volumeModel{
+		ID:           types.StringValue(volume.Meta.Id),
+		Name:         types.StringValue(volume.Name),
+		MountPath:    types.StringValue(volume.MountPath),
+		Size:         optionalString(volume.Size),
+		StorageClass: optionalString(volume.GetStorageClass()),
+		TTL:          optionalString(volume.GetTtl()),
 	}
+	switch {
+	case volume.GetEnvironmentId() != "":
+		state.EnvironmentID = types.StringValue(volume.GetEnvironmentId())
+	case volume.GetMcpId() != "":
+		state.McpID = types.StringValue(volume.GetMcpId())
+	}
+	return state
 }

--- a/internal/resources/volume_resource_test.go
+++ b/internal/resources/volume_resource_test.go
@@ -1,0 +1,44 @@
+package resources
+
+import (
+	"testing"
+
+	agentsv1 "github.com/agynio/terraform-provider-agyn/gen/agynio/api/agents/v1"
+)
+
+// An imported volume has no prior target in state, so the target has to come
+// back off the API or the next plan replaces the volume it just imported.
+func TestVolumeStateFromReadsTheTarget(t *testing.T) {
+	environmentVolume := &agentsv1.Volume{
+		Meta:      &agentsv1.EntityMeta{Id: "11111111-1111-1111-1111-111111111111"},
+		Name:      "workspace",
+		MountPath: "/workspace",
+		Size:      "10Gi",
+		Target:    &agentsv1.Volume_EnvironmentId{EnvironmentId: "22222222-2222-2222-2222-222222222222"},
+	}
+	state := volumeStateFrom(environmentVolume)
+	if got := state.EnvironmentID.ValueString(); got != "22222222-2222-2222-2222-222222222222" {
+		t.Fatalf("expected the environment target, got %q", got)
+	}
+	if !state.McpID.IsNull() {
+		t.Fatalf("expected mcp_id to stay null, got %q", state.McpID.ValueString())
+	}
+
+	mcpVolume := &agentsv1.Volume{
+		Meta:      &agentsv1.EntityMeta{Id: "33333333-3333-3333-3333-333333333333"},
+		Name:      "index",
+		MountPath: "/var/lib/index",
+		Target:    &agentsv1.Volume_McpId{McpId: "44444444-4444-4444-4444-444444444444"},
+	}
+	state = volumeStateFrom(mcpVolume)
+	if got := state.McpID.ValueString(); got != "44444444-4444-4444-4444-444444444444" {
+		t.Fatalf("expected the mcp target, got %q", got)
+	}
+	if !state.EnvironmentID.IsNull() {
+		t.Fatalf("expected environment_id to stay null, got %q", state.EnvironmentID.ValueString())
+	}
+	// No size is what makes a volume ephemeral scratch rather than a disk.
+	if !state.Size.IsNull() {
+		t.Fatalf("expected size to stay null, got %q", state.Size.ValueString())
+	}
+}


### PR DESCRIPTION
`agyn_environment.availability` could be set on create but never changed: `Update` built an `UpdateEnvironmentRequest` without it, so a changed value applied as a no-op and the API's unchanged value then contradicted the plan Terraform had just applied.

- Send `availability` on update, and validate it with `OneOf` rather than folding an unrecognized value into `internal`.
- Refresh the examples that volumes-on-environments invalidated: the volume example still declared the removed org-scoped attributes, and every example embedding an agent or an environment omitted the now-required `availability`.

Cutting v0.10.0 from this — v0.9.0 predates both the environment's `availability` and volumes moving onto environments, so neither is usable from Terraform today.